### PR TITLE
[config] make data path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Trading Backtest Project
+
+## Data path
+
+The project expects a CSV file with price data. By default the path is
+`data/btc_15m_data_2018_to_2025.csv` relative to the project root. You can use a
+different location by setting the environment variable `DATA_FILE` before running
+the program:
+
+```bash
+export DATA_FILE=/path/to/your/data.csv
+python run.py
+```
+
+Alternatively, place the CSV file at the default location and simply run
+`python run.py`.

--- a/trading_backtest/__main__.py
+++ b/trading_backtest/__main__.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 import pandas as pd
 
-from .config import RESULTS_FILE, SUMMARY_FILE, log
+from .config import RESULTS_FILE, SUMMARY_FILE, DATA_FILE, log
 from .data import load_price_data, add_indicator_cache
 from .optimize import (
-    optimize_with_optuna, PARAM_SPACES, prune_sma, refined_sma_grid, grid_search
+    optimize_with_optuna,
+    PARAM_SPACES,
+    prune_sma,
+    refined_sma_grid,
+    grid_search,
 )
 from .performance import PerformanceAnalyzer
 
@@ -14,16 +18,17 @@ from .strategy.breakout import BreakoutStrategy
 from .strategy.bollinger import BollingerBandStrategy
 from .strategy.momentum import MomentumImpulseStrategy, VolatilityExpansionStrategy
 
+
 def main() -> None:
     # 1) Dati + indicatori -------------------------------------------------
-    df = load_price_data(r"/Users/aleama/Desktop/trading_backtest_project/btc_15m_data_2018_to_2025.csv")
+    df = load_price_data(DATA_FILE)
     add_indicator_cache(
         df,
-        sma = list(range(5,251)) + [300,400],
-        rsi = [14],
-        atr = [14,21],
-        vol = [20,50],
-        imp = [5,10],
+        sma=list(range(5, 251)) + [300, 400],
+        rsi=[14],
+        atr=[14, 21],
+        vol=[20, 50],
+        imp=[5, 10],
     )
     # 2) Optuna (modulare!) ------------------------------------------------
     best_trial = optimize_with_optuna(
@@ -31,7 +36,7 @@ def main() -> None:
         SMACrossoverStrategy,
         PARAM_SPACES["sma"],
         prune_logic=prune_sma,
-        n_trials=300
+        n_trials=300,
     )
     sma_grid = refined_sma_grid(best_trial.params)
     grid_df = grid_search(df, sma_grid)
@@ -39,28 +44,54 @@ def main() -> None:
     log.info("Grid SMA salvato in %s", RESULTS_FILE)
 
     # 3) Strategie di riferimento ------------------------------------------
-    other=[]
-    other.append({"strategy":"RSI",
-                  "total_return": PerformanceAnalyzer(
-                      RSIStrategy(14,30,7,20).generate_trades(df)).total_return()})
-    other.append({"strategy":"Breakout",
-                  "total_return": PerformanceAnalyzer(
-                      BreakoutStrategy(55,14,1.0,7,20).generate_trades(df)).total_return()})
+    other = []
+    other.append(
+        {
+            "strategy": "RSI",
+            "total_return": PerformanceAnalyzer(
+                RSIStrategy(14, 30, 7, 20).generate_trades(df)
+            ).total_return(),
+        }
+    )
+    other.append(
+        {
+            "strategy": "Breakout",
+            "total_return": PerformanceAnalyzer(
+                BreakoutStrategy(55, 14, 1.0, 7, 20).generate_trades(df)
+            ).total_return(),
+        }
+    )
     vol_thr = df["vol_50"].quantile(0.80)
-    other.append({"strategy":"VolExpansion",
-                  "total_return": PerformanceAnalyzer(
-                      VolatilityExpansionStrategy(50,vol_thr,7,20).generate_trades(df)).total_return()})
-    other.append({"strategy":"Bollinger",
-                  "total_return": PerformanceAnalyzer(
-                      BollingerBandStrategy(20,2.0,7,15).generate_trades(df)).total_return()})
-    other.append({"strategy":"Momentum",
-                  "total_return": PerformanceAnalyzer(
-                      MomentumImpulseStrategy(10,0.02,7,20).generate_trades(df)).total_return()})
+    other.append(
+        {
+            "strategy": "VolExpansion",
+            "total_return": PerformanceAnalyzer(
+                VolatilityExpansionStrategy(50, vol_thr, 7, 20).generate_trades(df)
+            ).total_return(),
+        }
+    )
+    other.append(
+        {
+            "strategy": "Bollinger",
+            "total_return": PerformanceAnalyzer(
+                BollingerBandStrategy(20, 2.0, 7, 15).generate_trades(df)
+            ).total_return(),
+        }
+    )
+    other.append(
+        {
+            "strategy": "Momentum",
+            "total_return": PerformanceAnalyzer(
+                MomentumImpulseStrategy(10, 0.02, 7, 20).generate_trades(df)
+            ).total_return(),
+        }
+    )
 
     summary = pd.DataFrame(other).sort_values("total_return", ascending=False)
     summary.to_csv(SUMMARY_FILE, index=False)
     log.info("Riepilogo strategie salvato in %s", SUMMARY_FILE)
     log.info("=== PERFORMANCE ===\n%s", summary.to_string(index=False))
+
 
 if __name__ == "__main__":
     main()

--- a/trading_backtest/config.py
+++ b/trading_backtest/config.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
+import os
 from pathlib import Path
 import logging
 
-DATA_FILE    = Path("/content/btc_15m_data_2018_to_2025.csv")
+DATA_FILE = Path(os.environ.get("DATA_FILE", "data/btc_15m_data_2018_to_2025.csv"))
 RESULTS_FILE = Path("results_live.csv")
 SUMMARY_FILE = Path("summary_live.csv")
 


### PR DESCRIPTION
## Summary
- fetch price data using `DATA_FILE` from `config`
- allow configuring `DATA_FILE` via environment variable
- document how to set the data file path

## Testing
- `python run.py` *(fails: FileNotFoundError for data file)*

------
https://chatgpt.com/codex/tasks/task_e_683f6b617fb8832396b167719eee7e5b