### PR TITLE
[strategy] add trailing stop logic

### DIFF
--- a/tests/test_trailing_stop.py
+++ b/tests/test_trailing_stop.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from trading_backtest.strategy.base import BaseStrategy
+
+
+class DummyStrategy(BaseStrategy):
+    def prepare_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df
+
+    def entry_signal(self, df: pd.DataFrame) -> pd.Series:
+        sig = [True] + [False] * (len(df) - 1)
+        return pd.Series(sig, index=df.index)
+
+    def exit_signal(self, df: pd.DataFrame) -> pd.Series:
+        return pd.Series(False, index=df.index)
+
+
+def test_trailing_stop_closes_trade():
+    df = pd.DataFrame(
+        [
+            {"timestamp": 1, "close": 100, "high": 100, "low": 100},
+            {"timestamp": 2, "close": 110, "high": 110, "low": 101},
+            {"timestamp": 3, "close": 106, "high": 111, "low": 104},
+        ]
+    )
+    strat = DummyStrategy(sl_pct=0, tp_pct=100, trailing_stop_pct=5)
+    trades = strat.generate_trades(df)
+    assert len(trades) == 1
+    exit_price = trades.iloc[0]["exit"]
+    assert exit_price == pytest.approx(110 * (1 - 0.05))

--- a/trading_backtest/strategy/base.py
+++ b/trading_backtest/strategy/base.py
@@ -4,12 +4,16 @@ from abc import ABC, abstractmethod
 from typing import Any
 import pandas as pd
 
+
 class BaseStrategy(ABC):
     """Scheletro comune per strategie long-only."""
 
-    def __init__(self, sl_pct: float, tp_pct: float) -> None:
+    def __init__(
+        self, sl_pct: float, tp_pct: float, trailing_stop_pct: float | None = None
+    ) -> None:
         self.sl_pct = sl_pct
         self.tp_pct = tp_pct
+        self.trailing_stop_pct = trailing_stop_pct
 
     # ---------------- hooks da implementare --------------
     @abstractmethod
@@ -21,44 +25,62 @@ class BaseStrategy(ABC):
 
     # ---------------- motore trades ----------------------
     def generate_trades(self, df: pd.DataFrame) -> pd.DataFrame:
-        df      = self.prepare_indicators(df.copy())
+        df = self.prepare_indicators(df.copy())
         entries = self.entry_signal(df).fillna(False)
-        exits   = self.exit_signal(df).fillna(False)
+        exits = self.exit_signal(df).fillna(False)
 
         in_pos = False
+        trailing_sl = None
         trades: list[dict[str, Any]] = []
         for i, row in df.iterrows():
             if (not in_pos) and entries.at[i]:
-                in_pos   = True
-                e_price  = row["close"]
-                sl_price = e_price * (1 - self.sl_pct/100)
-                tp_price = e_price * (1 + self.tp_pct/100)
-                e_time   = row["timestamp"]
+                in_pos = True
+                e_price = row["close"]
+                sl_price = e_price * (1 - self.sl_pct / 100)
+                tp_price = e_price * (1 + self.tp_pct / 100)
+                if self.trailing_stop_pct:
+                    trailing_sl = e_price * (1 - self.trailing_stop_pct / 100)
+                    sl_price = max(sl_price, trailing_sl)
+                e_time = row["timestamp"]
                 continue
 
             if in_pos:
-                hit_sl     = row["low"]  <= sl_price
-                hit_tp     = row["high"] >= tp_price
+                hit_sl = row["low"] <= sl_price
+                hit_tp = row["high"] >= tp_price
                 force_exit = exits.at[i]
 
                 if hit_sl or hit_tp or force_exit:
-                    x_price = sl_price if hit_sl else tp_price if hit_tp else row["close"]
-                    trades.append({
-                        "entry_time": e_time,
-                        "exit_time" : row["timestamp"],
-                        "entry"     : e_price,
-                        "exit"      : x_price,
-                        "pct_change": (x_price/e_price - 1)*100,
-                    })
+                    x_price = (
+                        sl_price if hit_sl else tp_price if hit_tp else row["close"]
+                    )
+                    trades.append(
+                        {
+                            "entry_time": e_time,
+                            "exit_time": row["timestamp"],
+                            "entry": e_price,
+                            "exit": x_price,
+                            "pct_change": (x_price / e_price - 1) * 100,
+                        }
+                    )
                     in_pos = False
+                    trailing_sl = None
+                else:
+                    if self.trailing_stop_pct:
+                        new_trail = row["high"] * (1 - self.trailing_stop_pct / 100)
+                        if trailing_sl is None or new_trail > trailing_sl:
+                            trailing_sl = new_trail
+                        if trailing_sl > sl_price:
+                            sl_price = trailing_sl
 
         # chiusura forzata a fine serie
         if in_pos:
-            trades.append({
-                "entry_time": e_time,
-                "exit_time" : df.iloc[-1]["timestamp"],
-                "entry"     : e_price,
-                "exit"      : df.iloc[-1]["close"],
-                "pct_change": (df.iloc[-1]["close"]/e_price - 1)*100,
-            })
+            trades.append(
+                {
+                    "entry_time": e_time,
+                    "exit_time": df.iloc[-1]["timestamp"],
+                    "entry": e_price,
+                    "exit": df.iloc[-1]["close"],
+                    "pct_change": (df.iloc[-1]["close"] / e_price - 1) * 100,
+                }
+            )
         return pd.DataFrame(trades)

--- a/trading_backtest/strategy/sma.py
+++ b/trading_backtest/strategy/sma.py
@@ -2,14 +2,21 @@ from __future__ import annotations
 import pandas as pd
 from .base import BaseStrategy
 
+
 class SMACrossoverStrategy(BaseStrategy):
-    def __init__(self, sma_fast:int, sma_slow:int,
-                 sma_trend:int|None, sl_pct:float, tp_pct:float,
-                 position_size:int, trailing_stop_pct:float) -> None:
-        super().__init__(sl_pct, tp_pct)
+    def __init__(
+        self,
+        sma_fast: int,
+        sma_slow: int,
+        sma_trend: int | None,
+        sl_pct: float,
+        tp_pct: float,
+        position_size: int,
+        trailing_stop_pct: float,
+    ) -> None:
+        super().__init__(sl_pct, tp_pct, trailing_stop_pct)
         self.f, self.s, self.tr = sma_fast, sma_slow, sma_trend
         self.position_size = position_size
-        self.trailing_stop_pct = trailing_stop_pct
 
     def prepare_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
         df["f"] = df[f"sma_{self.f}"]
@@ -29,4 +36,3 @@ class SMACrossoverStrategy(BaseStrategy):
     def trailing_stop(self, entry_price: float, current_price: float) -> float:
         trailing_stop_price = entry_price * (1 - self.trailing_stop_pct / 100)
         return trailing_stop_price if current_price > entry_price else entry_price
-


### PR DESCRIPTION
## Summary
- extend `BaseStrategy` with optional `trailing_stop_pct`
- implement dynamic trailing stop in `generate_trades`
- update SMA strategy constructor
- add unit test for trailing stop exits

## Testing
- `pytest -q`
- `python run.py` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_683f6b6c208c8323874142c052a52165