### PR TITLE
[main] add helper to run reference strategies

### DIFF
--- a/trading_backtest/__main__.py
+++ b/trading_backtest/__main__.py
@@ -19,6 +19,12 @@ from .strategy.bollinger import BollingerBandStrategy
 from .strategy.momentum import MomentumImpulseStrategy, VolatilityExpansionStrategy
 
 
+def run_reference_strategy(df: pd.DataFrame, strategy_instance) -> float:
+    """Return total return for a given strategy instance."""
+    trades = strategy_instance.generate_trades(df)
+    return PerformanceAnalyzer(trades).total_return()
+
+
 def main() -> None:
     # 1) Dati + indicatori -------------------------------------------------
     df = load_price_data(DATA_FILE)
@@ -48,42 +54,40 @@ def main() -> None:
     other.append(
         {
             "strategy": "RSI",
-            "total_return": PerformanceAnalyzer(
-                RSIStrategy(14, 30, 7, 20).generate_trades(df)
-            ).total_return(),
+            "total_return": run_reference_strategy(df, RSIStrategy(14, 30, 7, 20)),
         }
     )
     other.append(
         {
             "strategy": "Breakout",
-            "total_return": PerformanceAnalyzer(
-                BreakoutStrategy(55, 14, 1.0, 7, 20).generate_trades(df)
-            ).total_return(),
+            "total_return": run_reference_strategy(
+                df, BreakoutStrategy(55, 14, 1.0, 7, 20)
+            ),
         }
     )
     vol_thr = df["vol_50"].quantile(0.80)
     other.append(
         {
             "strategy": "VolExpansion",
-            "total_return": PerformanceAnalyzer(
-                VolatilityExpansionStrategy(50, vol_thr, 7, 20).generate_trades(df)
-            ).total_return(),
+            "total_return": run_reference_strategy(
+                df, VolatilityExpansionStrategy(50, vol_thr, 7, 20)
+            ),
         }
     )
     other.append(
         {
             "strategy": "Bollinger",
-            "total_return": PerformanceAnalyzer(
-                BollingerBandStrategy(20, 2.0, 7, 15).generate_trades(df)
-            ).total_return(),
+            "total_return": run_reference_strategy(
+                df, BollingerBandStrategy(20, 2.0, 7, 15)
+            ),
         }
     )
     other.append(
         {
             "strategy": "Momentum",
-            "total_return": PerformanceAnalyzer(
-                MomentumImpulseStrategy(10, 0.02, 7, 20).generate_trades(df)
-            ).total_return(),
+            "total_return": run_reference_strategy(
+                df, MomentumImpulseStrategy(10, 0.02, 7, 20)
+            ),
         }
     )
 


### PR DESCRIPTION
## Summary
- add `run_reference_strategy` helper to compute `total_return`
- use helper when evaluating reference strategies

## Testing
- `python run.py` *(fails: FileNotFoundError)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684015ccc7808323837497f560e08ae4