### PR TITLE
[strategy] refactor trade logic

### DIFF
--- a/trading_backtest/strategy/base.py
+++ b/trading_backtest/strategy/base.py
@@ -1,8 +1,26 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any
 import pandas as pd
+
+
+@dataclass
+class Trade:
+    entry_time: Any
+    exit_time: Any
+    entry: float
+    exit: float
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "entry_time": self.entry_time,
+            "exit_time": self.exit_time,
+            "entry": self.entry,
+            "exit": self.exit,
+            "pct_change": (self.exit / self.entry - 1) * 100,
+        }
 
 
 class BaseStrategy(ABC):
@@ -31,17 +49,11 @@ class BaseStrategy(ABC):
 
         in_pos = False
         trailing_sl = None
-        trades: list[dict[str, Any]] = []
+        trades: list[Trade] = []
         for i, row in df.iterrows():
             if (not in_pos) and entries.at[i]:
                 in_pos = True
-                e_price = row["close"]
-                sl_price = e_price * (1 - self.sl_pct / 100)
-                tp_price = e_price * (1 + self.tp_pct / 100)
-                if self.trailing_stop_pct:
-                    trailing_sl = e_price * (1 - self.trailing_stop_pct / 100)
-                    sl_price = max(sl_price, trailing_sl)
-                e_time = row["timestamp"]
+                e_price, sl_price, tp_price, trailing_sl, e_time = self._open_trade(row)
                 continue
 
             if in_pos:
@@ -50,37 +62,68 @@ class BaseStrategy(ABC):
                 force_exit = exits.at[i]
 
                 if hit_sl or hit_tp or force_exit:
-                    x_price = (
-                        sl_price if hit_sl else tp_price if hit_tp else row["close"]
+                    trade = self._close_trade(
+                        row, e_time, e_price, sl_price, tp_price, hit_sl, hit_tp
                     )
-                    trades.append(
-                        {
-                            "entry_time": e_time,
-                            "exit_time": row["timestamp"],
-                            "entry": e_price,
-                            "exit": x_price,
-                            "pct_change": (x_price / e_price - 1) * 100,
-                        }
-                    )
+                    trades.append(trade)
                     in_pos = False
                     trailing_sl = None
                 else:
-                    if self.trailing_stop_pct:
-                        new_trail = row["high"] * (1 - self.trailing_stop_pct / 100)
-                        if trailing_sl is None or new_trail > trailing_sl:
-                            trailing_sl = new_trail
-                        if trailing_sl > sl_price:
-                            sl_price = trailing_sl
+                    sl_price, trailing_sl = self._update_trailing_stop(
+                        row, sl_price, trailing_sl
+                    )
 
-        # chiusura forzata a fine serie
         if in_pos:
             trades.append(
-                {
-                    "entry_time": e_time,
-                    "exit_time": df.iloc[-1]["timestamp"],
-                    "entry": e_price,
-                    "exit": df.iloc[-1]["close"],
-                    "pct_change": (df.iloc[-1]["close"] / e_price - 1) * 100,
-                }
+                Trade(
+                    entry_time=e_time,
+                    exit_time=df.iloc[-1]["timestamp"],
+                    entry=e_price,
+                    exit=df.iloc[-1]["close"],
+                )
             )
-        return pd.DataFrame(trades)
+        return pd.DataFrame([t.as_dict() for t in trades])
+
+    # ---------------- metodi interni ----------------------
+    def _open_trade(
+        self, row: pd.Series
+    ) -> tuple[float, float, float, float | None, Any]:
+        e_price = row["close"]
+        sl_price = e_price * (1 - self.sl_pct / 100)
+        tp_price = e_price * (1 + self.tp_pct / 100)
+        trailing_sl = None
+        if self.trailing_stop_pct:
+            trailing_sl = e_price * (1 - self.trailing_stop_pct / 100)
+            sl_price = max(sl_price, trailing_sl)
+        return e_price, sl_price, tp_price, trailing_sl, row["timestamp"]
+
+    def _update_trailing_stop(
+        self, row: pd.Series, sl_price: float, trailing_sl: float | None
+    ) -> tuple[float, float | None]:
+        if not self.trailing_stop_pct:
+            return sl_price, trailing_sl
+
+        new_trail = row["high"] * (1 - self.trailing_stop_pct / 100)
+        if trailing_sl is None or new_trail > trailing_sl:
+            trailing_sl = new_trail
+        if trailing_sl is not None and trailing_sl > sl_price:
+            sl_price = trailing_sl
+        return sl_price, trailing_sl
+
+    def _close_trade(
+        self,
+        row: pd.Series,
+        e_time: Any,
+        e_price: float,
+        sl_price: float,
+        tp_price: float,
+        hit_sl: bool,
+        hit_tp: bool,
+    ) -> Trade:
+        x_price = sl_price if hit_sl else tp_price if hit_tp else row["close"]
+        return Trade(
+            entry_time=e_time,
+            exit_time=row["timestamp"],
+            entry=e_price,
+            exit=x_price,
+        )


### PR DESCRIPTION
## Summary
- refactor BaseStrategy trade generation logic
- add Trade dataclass
- extract trade opening, closing and trailing logic to private methods

## Testing
- `pytest -q`
- `python run.py` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684015ce1b288323b9a68eae852d61ba