### PR TITLE
[config] Default DATA_FILE path update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## Data path
 
-The project expects a CSV file with price data. By default the path is
+The project expects a CSV file with price data. If the environment variable
+`DATA_FILE` is not set, the default path is
 `data/btc_15m_data_2018_to_2025.csv` relative to the project root. You can use a
-different location by setting the environment variable `DATA_FILE` before running
-the program:
+different location by setting `DATA_FILE` before running the program:
 
 ```bash
 export DATA_FILE=/path/to/your/data.csv

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,10 @@
+import importlib
+from pathlib import Path
+
+import trading_backtest.config as cfg
+
+
+def test_data_file_default(monkeypatch):
+    monkeypatch.delenv("DATA_FILE", raising=False)
+    importlib.reload(cfg)
+    assert cfg.DATA_FILE == Path("data/btc_15m_data_2018_to_2025.csv")

--- a/trading_backtest/config.py
+++ b/trading_backtest/config.py
@@ -2,8 +2,8 @@ import os
 from pathlib import Path
 import logging
 
-# Usa variabile d'ambiente se disponibile, altrimenti fallback su path Codex
-DATA_FILE = Path(os.environ.get("DATA_FILE", "/content/btc_15m_data_2018_to_2025.csv"))
+# Usa variabile d'ambiente se disponibile, altrimenti path relativo al progetto
+DATA_FILE = Path(os.environ.get("DATA_FILE", "data/btc_15m_data_2018_to_2025.csv"))
 RESULTS_FILE = Path("results_live.csv")
 SUMMARY_FILE = Path("summary_live.csv")
 


### PR DESCRIPTION
## Summary
- default DATA_FILE now falls back to `data/btc_15m_data_2018_to_2025.csv`
- clarify README about the default behaviour
- add regression test verifying the default path

## Testing
- `black trading_backtest/config.py tests/test_config.py`
- `pytest -q` *(fails: tests/test_strategy.py::test_rsi_strategy_generate_single_trade)*

------
https://chatgpt.com/codex/tasks/task_e_68414c6ad5288323afab4d666c3ec564