### PR TITLE
[style] Run black on trading_backtest and tests

### DIFF
--- a/tests/test_optuna_param_spaces.py
+++ b/tests/test_optuna_param_spaces.py
@@ -79,8 +79,18 @@ def test_optimize_instantiates_strategies():
         (SMACrossoverStrategy, SMAConfig, PARAM_SPACES["sma"], prune_sma),
         (RSIStrategy, RSIConfig, PARAM_SPACES["rsi"], prune_rsi),
         (BreakoutStrategy, BreakoutConfig, PARAM_SPACES["breakout"], prune_breakout),
-        (BollingerBandStrategy, BollingerConfig, PARAM_SPACES["bollinger"], prune_bollinger),
-        (MomentumImpulseStrategy, MomentumConfig, PARAM_SPACES["momentum"], prune_momentum),
+        (
+            BollingerBandStrategy,
+            BollingerConfig,
+            PARAM_SPACES["bollinger"],
+            prune_bollinger,
+        ),
+        (
+            MomentumImpulseStrategy,
+            MomentumConfig,
+            PARAM_SPACES["momentum"],
+            prune_momentum,
+        ),
         (
             VolatilityExpansionStrategy,
             VolExpansionConfig,

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -33,4 +33,3 @@ def test_rsi_strategy_invalid_sl_tp():
     cfg = RSIConfig(period=14, oversold=30, sl_pct=10, tp_pct=5)
     with pytest.raises(ValueError):
         RSIStrategy(cfg)
-

--- a/tests/test_trailing_stop.py
+++ b/tests/test_trailing_stop.py
@@ -34,7 +34,7 @@ def test_trailing_stop_closes_trade():
     assert trade["qty"] == 1
     assert trade["exit"] == pytest.approx(110 * (1 - 0.05))
 
+
 def test_trailing_stop_pct_must_be_positive():
     with pytest.raises(ValueError):
         DummyStrategy(sl_pct=1, tp_pct=2, trailing_stop_pct=0)
-

--- a/trading_backtest/__main__.py
+++ b/trading_backtest/__main__.py
@@ -112,4 +112,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/trading_backtest/strategy/base.py
+++ b/trading_backtest/strategy/base.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 import pandas as pd
 
+
 @dataclass
 class Trade:
     entry_time: Any
@@ -22,6 +23,7 @@ class Trade:
             "pct_change": (self.exit / self.entry - 1) * 100,
             "qty": self.qty,
         }
+
 
 class BaseStrategy(ABC):
     """Scheletro comune per strategie long-only."""
@@ -59,7 +61,9 @@ class BaseStrategy(ABC):
         for i, row in df.iterrows():
             if (not in_pos) and entries.at[i]:
                 in_pos = True
-                e_price, sl_price, tp_price, trailing_sl, e_time, qty = self._open_trade(row)
+                e_price, sl_price, tp_price, trailing_sl, e_time, qty = (
+                    self._open_trade(row)
+                )
                 continue
 
             if in_pos:
@@ -137,4 +141,3 @@ class BaseStrategy(ABC):
             exit=x_price,
             qty=qty,
         )
-


### PR DESCRIPTION
## Summary
- format code under `trading_backtest` and `tests` with `black`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: AssertionError in `test_rsi_strategy_generate_single_trade`)*

------
https://chatgpt.com/codex/tasks/task_e_68414f7dc9508323bc2c392fca6fb9ce