### PR TITLE
[performance] add sharpe, mdd, win rate

### DIFF
--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import pytest
 from trading_backtest.performance import PerformanceAnalyzer
 
 
@@ -7,3 +8,20 @@ def test_total_return_with_commission_and_slippage():
     pa = PerformanceAnalyzer(trades, commission=0.1, slippage=0.2)
     expected = (10 - 0.1 - 0.2) + (-5 - 0.1 - 0.2) + (2.5 - 0.1 - 0.2)
     assert pa.total_return() == expected
+
+
+def test_sharpe_ratio():
+    trades = pd.DataFrame({"pct_change": [10.0, -5.0, 15.0]})
+    pa = PerformanceAnalyzer(trades)
+    r = trades["pct_change"]
+    expected = (r.mean() / r.std()) * (len(r) ** 0.5)
+    assert pa.sharpe_ratio() == pytest.approx(expected)
+
+
+def test_max_drawdown_and_win_rate():
+    trades = pd.DataFrame({"pct_change": [10, -5, 15, -20, 5]})
+    pa = PerformanceAnalyzer(trades)
+    equity = (1 + trades["pct_change"] / 100).cumprod()
+    dd = equity.div(equity.cummax()).sub(1) * 100
+    assert pa.max_drawdown() == dd.min()
+    assert pa.win_rate() == (3 / 5) * 100

--- a/trading_backtest/performance.py
+++ b/trading_backtest/performance.py
@@ -19,3 +19,27 @@ class PerformanceAnalyzer:
 
     def avg_trade(self) -> float:
         return self.trades["net_pct"].mean() if not self.trades.empty else 0.0
+
+    def sharpe_ratio(self) -> float:
+        """Return the simple Sharpe ratio based on ``net_pct`` returns."""
+        if self.trades.empty:
+            return 0.0
+        r = self.trades["net_pct"]
+        std = r.std()
+        if std == 0 or len(r) == 0:
+            return 0.0
+        return (r.mean() / std) * (len(r) ** 0.5)
+
+    def max_drawdown(self) -> float:
+        """Return the maximum drawdown in percent."""
+        if self.trades.empty:
+            return 0.0
+        equity = (1 + self.trades["net_pct"] / 100).cumprod()
+        drawdown = equity.div(equity.cummax()).sub(1) * 100
+        return drawdown.min()
+
+    def win_rate(self) -> float:
+        """Return the percentage of profitable trades."""
+        if self.trades.empty:
+            return 0.0
+        return (self.trades["net_pct"] > 0).mean() * 100


### PR DESCRIPTION
## Summary
- compute Sharpe ratio, maximum drawdown and win rate in `PerformanceAnalyzer`
- add unit tests for the new metrics

## Testing
- `python run.py` *(fails: data file not found)*
- `pytest -q` *(fails: tests/test_strategy.py::test_rsi_strategy_generate_single_trade)*

------
https://chatgpt.com/codex/tasks/task_e_684151daf1c883239e17970fe8990971