### PR TITLE
[core] use config objects when creating strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ generated DataFrame now includes a `qty` column with this value:
 
 ```python
 from trading_backtest.strategy.sma import SMACrossoverStrategy
+from trading_backtest.config import SMAConfig
 
-strat = SMACrossoverStrategy(
+cfg = SMAConfig(
     sma_fast=10,
     sma_slow=50,
     sma_trend=200,
@@ -59,6 +60,7 @@ strat = SMACrossoverStrategy(
     position_size=0.1,
     trailing_stop_pct=2.0,
 )
+strat = SMACrossoverStrategy(cfg)
 trades = strat.generate_trades(df)
 ```
 

--- a/tests/test_trailing_stop.py
+++ b/tests/test_trailing_stop.py
@@ -4,10 +4,21 @@ import pandas as pd
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from dataclasses import dataclass
 from trading_backtest.strategy.base import BaseStrategy
 
 
+@dataclass
+class DummyConfig:
+    sl_pct: float
+    tp_pct: float
+    trailing_stop_pct: float
+
+
 class DummyStrategy(BaseStrategy):
+    def __init__(self, config: DummyConfig):
+        super().__init__(config)
+
     def prepare_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
         return df
 
@@ -27,7 +38,8 @@ def test_trailing_stop_closes_trade():
             {"timestamp": 3, "close": 106, "high": 111, "low": 104},
         ]
     )
-    strat = DummyStrategy(sl_pct=0, tp_pct=100, trailing_stop_pct=5)
+    cfg = DummyConfig(sl_pct=0, tp_pct=100, trailing_stop_pct=5)
+    strat = DummyStrategy(cfg)
     trades = strat.generate_trades(df)
     assert len(trades) == 1
     trade = trades.iloc[0]
@@ -37,4 +49,4 @@ def test_trailing_stop_closes_trade():
 
 def test_trailing_stop_pct_must_be_positive():
     with pytest.raises(ValueError):
-        DummyStrategy(sl_pct=1, tp_pct=2, trailing_stop_pct=0)
+        DummyStrategy(DummyConfig(sl_pct=1, tp_pct=2, trailing_stop_pct=0))

--- a/trading_backtest/__main__.py
+++ b/trading_backtest/__main__.py
@@ -67,14 +67,21 @@ def main() -> None:
     other.append(
         {
             "strategy": "RSI",
-            "total_return": run_reference_strategy(df, RSIStrategy(RSIConfig(period=14, oversold=30, sl_pct=7, tp_pct=20))),
+            "total_return": run_reference_strategy(
+                df, RSIStrategy(RSIConfig(period=14, oversold=30, sl_pct=7, tp_pct=20))
+            ),
         }
     )
     other.append(
         {
             "strategy": "Breakout",
             "total_return": run_reference_strategy(
-                df, BreakoutStrategy(55, 14, 1.0, 7, 20)
+                df,
+                BreakoutStrategy(
+                    BreakoutConfig(
+                        lookback=55, atr_period=14, atr_mult=1.0, sl_pct=7, tp_pct=20
+                    )
+                ),
             ),
         }
     )
@@ -83,7 +90,12 @@ def main() -> None:
         {
             "strategy": "VolExpansion",
             "total_return": run_reference_strategy(
-                df, VolatilityExpansionStrategy(50, vol_thr, 7, 20)
+                df,
+                VolatilityExpansionStrategy(
+                    VolExpansionConfig(
+                        vol_window=50, vol_threshold=vol_thr, sl_pct=7, tp_pct=20
+                    )
+                ),
             ),
         }
     )
@@ -91,7 +103,10 @@ def main() -> None:
         {
             "strategy": "Bollinger",
             "total_return": run_reference_strategy(
-                df, BollingerBandStrategy(20, 2.0, 7, 15)
+                df,
+                BollingerBandStrategy(
+                    BollingerConfig(period=20, nstd=2.0, sl_pct=7, tp_pct=15)
+                ),
             ),
         }
     )
@@ -99,7 +114,10 @@ def main() -> None:
         {
             "strategy": "Momentum",
             "total_return": run_reference_strategy(
-                df, MomentumImpulseStrategy(10, 0.02, 7, 20)
+                df,
+                MomentumImpulseStrategy(
+                    MomentumConfig(window=10, threshold=0.02, sl_pct=7, tp_pct=20)
+                ),
             ),
         }
     )


### PR DESCRIPTION
## Summary
- instantiate strategies via config objects in `__main__`
- adapt trailing stop tests to new API
- document new pattern in README

## Testing
- `black trading_backtest/ tests/test_trailing_stop.py`
- `pytest -q`
- `python run.py` *(interrupted after verifying start)*


------
https://chatgpt.com/codex/tasks/task_e_68415ff7e1d88323b2cd4e0736dd592a