### PR TITLE
[optimize] add SL/TP pruning helper

### DIFF
--- a/tests/test_optuna_param_spaces.py
+++ b/tests/test_optuna_param_spaces.py
@@ -1,8 +1,10 @@
 import pathlib
 import sys
 
+import optuna
 import pandas as pd
 import numpy as np
+import pytest
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
@@ -15,6 +17,7 @@ from trading_backtest.optimize import (
     prune_bollinger,
     prune_momentum,
     prune_vol_expansion,
+    check_sl_tp,
 )
 from trading_backtest.strategy.sma import SMACrossoverStrategy
 from trading_backtest.strategy.rsi import RSIStrategy
@@ -100,3 +103,9 @@ def test_optimize_instantiates_strategies():
     ]
     for cls, cfg_cls, space, prune in configs:
         optimize_with_optuna(df, cls, cfg_cls, space, prune_logic=prune, n_trials=1)
+
+
+def test_check_sl_tp_pruning():
+    check_sl_tp({"sl_pct": 5, "tp_pct": 10})
+    with pytest.raises(optuna.TrialPruned):
+        check_sl_tp({"sl_pct": 10, "tp_pct": 5})

--- a/trading_backtest/optimize.py
+++ b/trading_backtest/optimize.py
@@ -93,42 +93,43 @@ def suggest(trial, param_info, name=None):
 
 
 # ---------------------- PRUNE -----------------------------
+def check_sl_tp(params: dict[str, Any]) -> None:
+    """Raise :class:`optuna.TrialPruned` when stop loss is not less than take profit."""
+
+    if params["sl_pct"] >= params["tp_pct"]:
+        raise optuna.TrialPruned()
+
+
 def prune_sma(params, trial):
     """Prune trials where SMA parameters are inconsistent."""
+    check_sl_tp(params)
     if params["sma_fast"] >= params["sma_slow"]:
-        raise optuna.TrialPruned()
-    if params["sl_pct"] >= params["tp_pct"]:
         raise optuna.TrialPruned()
 
 
 def prune_rsi(params, trial):
     """Prune RSI trials with invalid stop or take-profit."""
-    if params["sl_pct"] >= params["tp_pct"]:
-        raise optuna.TrialPruned()
+    check_sl_tp(params)
 
 
 def prune_breakout(params, trial):
     """Prune breakout trials with invalid stop or take-profit."""
-    if params["sl_pct"] >= params["tp_pct"]:
-        raise optuna.TrialPruned()
+    check_sl_tp(params)
 
 
 def prune_bollinger(params, trial):
     """Prune Bollinger trials with invalid stop or take-profit."""
-    if params["sl_pct"] >= params["tp_pct"]:
-        raise optuna.TrialPruned()
+    check_sl_tp(params)
 
 
 def prune_momentum(params, trial):
     """Prune momentum trials with invalid stop or take-profit."""
-    if params["sl_pct"] >= params["tp_pct"]:
-        raise optuna.TrialPruned()
+    check_sl_tp(params)
 
 
 def prune_vol_expansion(params, trial):
     """Prune volatility expansion trials with invalid stop or take-profit."""
-    if params["sl_pct"] >= params["tp_pct"]:
-        raise optuna.TrialPruned()
+    check_sl_tp(params)
 
 
 # ---------------------- STRATEGY EVALUATION -----------------------------


### PR DESCRIPTION
## Summary
- add `check_sl_tp` utility to centralize stop-loss vs take-profit validation
- simplify prune helpers to call the new function
- test the new helper

## Testing
- `black trading_backtest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684173151c348323ab410a8659388ce4