### PR TITLE
[strategy] use itertuples in trade generator

### DIFF
--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -25,6 +25,8 @@ def test_rsi_strategy_generate_single_trade():
     assert trade["qty"] == 1
     assert trade["entry_time"] == df.loc[2, "timestamp"]
     assert trade["exit_time"] == df.loc[4, "timestamp"]
+    assert trade["entry"] == df.loc[2, "close"]
+    assert trade["exit"] == df.loc[4, "close"]
     expected_pct = (df.loc[4, "close"] / df.loc[2, "close"] - 1) * 100
     assert trade["pct_change"] == expected_pct
 

--- a/tests/test_trailing_stop.py
+++ b/tests/test_trailing_stop.py
@@ -45,6 +45,9 @@ def test_trailing_stop_closes_trade():
     trade = trades.iloc[0]
     assert trade["qty"] == 1
     assert trade["exit"] == pytest.approx(110 * (1 - 0.05))
+    assert trade["entry_time"] == 1
+    assert trade["exit_time"] == 3
+    assert trade["entry"] == 100
 
 
 def test_trailing_stop_pct_must_be_positive():


### PR DESCRIPTION
## Summary
- iterate over DataFrame rows using `itertuples` in `BaseStrategy.generate_trades`
- adjust internal helper methods to accept tuple rows
- verify behaviour with extended tests for DummyStrategy and RSIStrategy

## Testing
- `black trading_backtest/ tests/test_trailing_stop.py tests/test_strategy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417316e82883238c5a6e0023a0da8b