### PR TITLE
[strategy] centralize strategy registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ accepts an additional `position_size` parameter used to size trades. The
 generated DataFrame now includes a `qty` column with this value:
 
 ```python
-from trading_backtest.strategy.sma import SMACrossoverStrategy
+from trading_backtest.strategy import get_strategy
 from trading_backtest.config import SMAConfig
 
 cfg = SMAConfig(
@@ -60,7 +60,8 @@ cfg = SMAConfig(
     position_size=0.1,
     trailing_stop_pct=2.0,
 )
-strat = SMACrossoverStrategy(cfg)
+strategy_cls, _ = get_strategy("sma")
+strat = strategy_cls(cfg)
 trades = strat.generate_trades(df)
 ```
 

--- a/tests/test_generate_trades.py
+++ b/tests/test_generate_trades.py
@@ -2,14 +2,7 @@ import pandas as pd
 import numpy as np
 import pytest
 
-from trading_backtest.strategy.sma import SMACrossoverStrategy
-from trading_backtest.strategy.rsi import RSIStrategy
-from trading_backtest.strategy.breakout import BreakoutStrategy
-from trading_backtest.strategy.bollinger import BollingerBandStrategy
-from trading_backtest.strategy.momentum import (
-    MomentumImpulseStrategy,
-    VolatilityExpansionStrategy,
-)
+from trading_backtest.strategy import get_strategy
 from trading_backtest.config import (
     SMAConfig,
     RSIConfig,
@@ -45,10 +38,10 @@ def _dummy_df() -> pd.DataFrame:
 
 
 @pytest.mark.parametrize(
-    "strategy_cls, cfg",
+    "name, cfg",
     [
         (
-            SMACrossoverStrategy,
+            "sma",
             SMAConfig(
                 sma_fast=5,
                 sma_slow=10,
@@ -59,34 +52,28 @@ def _dummy_df() -> pd.DataFrame:
                 trailing_stop_pct=1,
             ),
         ),
+        ("rsi", RSIConfig(period=14, oversold=30, sl_pct=1, tp_pct=2)),
         (
-            RSIStrategy,
-            RSIConfig(period=14, oversold=30, sl_pct=1, tp_pct=2),
-        ),
-        (
-            BreakoutStrategy,
+            "breakout",
             BreakoutConfig(
-                lookback=20, atr_period=14, atr_mult=1.0, sl_pct=1, tp_pct=2
+                lookback=20,
+                atr_period=14,
+                atr_mult=1.0,
+                sl_pct=1,
+                tp_pct=2,
             ),
         ),
+        ("bollinger", BollingerConfig(period=20, nstd=2.0, sl_pct=1, tp_pct=2)),
+        ("momentum", MomentumConfig(window=10, threshold=0, sl_pct=1, tp_pct=2)),
         (
-            BollingerBandStrategy,
-            BollingerConfig(period=20, nstd=2.0, sl_pct=1, tp_pct=2),
-        ),
-        (
-            MomentumImpulseStrategy,
-            MomentumConfig(window=10, threshold=0, sl_pct=1, tp_pct=2),
-        ),
-        (
-            VolatilityExpansionStrategy,
-            VolExpansionConfig(
-                vol_window=20, vol_threshold=0.4, sl_pct=1, tp_pct=2
-            ),
+            "vol_expansion",
+            VolExpansionConfig(vol_window=20, vol_threshold=0.4, sl_pct=1, tp_pct=2),
         ),
     ],
 )
-def test_generate_trades_runs(strategy_cls, cfg):
+def test_generate_trades_runs(name, cfg):
     df = _dummy_df()
+    strategy_cls, _ = get_strategy(name)
     strat = strategy_cls(cfg)
     trades = strat.generate_trades(df)
     assert isinstance(trades, pd.DataFrame)

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from trading_backtest.strategy.rsi import RSIStrategy
+from trading_backtest.strategy import get_strategy
 from trading_backtest.config import RSIConfig
 
 
@@ -17,7 +17,8 @@ def test_rsi_strategy_generate_single_trade():
         }
     )
     cfg = RSIConfig(period=14, oversold=30, sl_pct=40, tp_pct=50)
-    strat = RSIStrategy(cfg)
+    strategy_cls, _ = get_strategy("rsi")
+    strat = strategy_cls(cfg)
     trades = strat.generate_trades(df)
     assert len(trades) == 1
 
@@ -33,5 +34,6 @@ def test_rsi_strategy_generate_single_trade():
 
 def test_rsi_strategy_invalid_sl_tp():
     cfg = RSIConfig(period=14, oversold=30, sl_pct=10, tp_pct=5)
+    strategy_cls, _ = get_strategy("rsi")
     with pytest.raises(ValueError):
-        RSIStrategy(cfg)
+        strategy_cls(cfg)

--- a/trading_backtest/optimize.py
+++ b/trading_backtest/optimize.py
@@ -92,7 +92,6 @@ PARAM_SPACES = {
 }
 
 
-
 # ---------------------- SUGGEST UNIVERSALE ---------------------------
 def suggest(trial, param_info, name=None):
     """Wrapper around Optuna suggest functions with basic validation."""
@@ -224,15 +223,16 @@ def optimize_with_optuna(
 
 
 # ---------------------- RETROCOMPATIBILITA' SMA ----------------------
-from .strategy.sma import SMACrossoverStrategy
+from .strategy import get_strategy
 
 
 def optimize_sma(df: pd.DataFrame, n_trials: int = 300):
     """Backward-compatible wrapper to optimize the SMA strategy."""
+    strategy_cls, config_cls = get_strategy("sma")
     return optimize_with_optuna(
         df,
-        SMACrossoverStrategy,
-        SMAConfig,
+        strategy_cls,
+        config_cls,
         PARAM_SPACES["sma"],
         prune_logic=prune_sma,
         n_trials=n_trials,
@@ -280,8 +280,9 @@ def grid_search(df: pd.DataFrame, combos: list[dict[str, Any]]) -> pd.DataFrame:
 
     log.info("Grid SMA – %d combo", len(combos))
     results = []
+    strategy_cls, _ = get_strategy("sma")
     for p in tqdm(combos, desc="SMA"):
         cfg = SMAConfig(**p)
-        ret = evaluate_strategy(df, lambda cfg=cfg: SMACrossoverStrategy(cfg))
+        ret = evaluate_strategy(df, lambda cfg=cfg: strategy_cls(cfg))
         results.append({**p, "total_return": ret})
     return pd.DataFrame(results).sort_values("total_return", ascending=False)

--- a/trading_backtest/strategy/__init__.py
+++ b/trading_backtest/strategy/__init__.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from ..config import (
+    SMAConfig,
+    RSIConfig,
+    BreakoutConfig,
+    BollingerConfig,
+    MomentumConfig,
+    VolExpansionConfig,
+)
+
+from .sma import SMACrossoverStrategy
+from .rsi import RSIStrategy
+from .breakout import BreakoutStrategy
+from .bollinger import BollingerBandStrategy
+from .momentum import MomentumImpulseStrategy, VolatilityExpansionStrategy
+
+STRATEGY_REGISTRY: dict[str, tuple[type, type]] = {}
+
+
+def register_strategy(name: str, cls: type, config_cls: type) -> None:
+    """Register a strategy class and its config."""
+    STRATEGY_REGISTRY[name] = (cls, config_cls)
+
+
+def get_strategy(name: str) -> tuple[type, type]:
+    """Return ``(strategy_cls, config_cls)`` for ``name``."""
+    return STRATEGY_REGISTRY[name]
+
+
+register_strategy("sma", SMACrossoverStrategy, SMAConfig)
+register_strategy("rsi", RSIStrategy, RSIConfig)
+register_strategy("breakout", BreakoutStrategy, BreakoutConfig)
+register_strategy("bollinger", BollingerBandStrategy, BollingerConfig)
+register_strategy("momentum", MomentumImpulseStrategy, MomentumConfig)
+register_strategy(
+    "vol_expansion",
+    VolatilityExpansionStrategy,
+    VolExpansionConfig,
+)


### PR DESCRIPTION
## Summary
- add STRATEGY_REGISTRY in strategy package
- reference strategies by name via `get_strategy`
- update optimize module, tests and docs to use the registry

## Testing
- `black trading_backtest tests --line-length 88`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684197fbb8948323b93a6b04b57ee12a