### PR TITLE
[data] refactor indicator cache

### DIFF
--- a/tests/test_indicator_cache.py
+++ b/tests/test_indicator_cache.py
@@ -45,9 +45,28 @@ def test_add_indicator_cache_small_df():
     # Impulse
     expected[f"impulse_{w}"] = expected["close"].pct_change(w).shift(1)
 
-    add_indicator_cache(df, sma=[2], rsi=[2], atr=[2], vol=[2], imp=[2])
+    # Breakout high max
+    expected[f"hmax_{w}"] = expected["close"].shift(1).rolling(w).max()
 
-    for col in ["sma_2", "rsi_2", "tr", "atr_2", "vol_2", "impulse_2"]:
+    # Bollinger bands
+    expected[f"bbm_{w}"] = expected["close"].rolling(w).mean().shift(1)
+    expected[f"bbs_{w}"] = expected["close"].rolling(w).std().shift(1)
+
+    add_indicator_cache(
+        df, sma=[2], rsi=[2], atr=[2], vol=[2], imp=[2], hmax=[2], bb=[2]
+    )
+
+    for col in [
+        "sma_2",
+        "rsi_2",
+        "tr",
+        "atr_2",
+        "vol_2",
+        "impulse_2",
+        "hmax_2",
+        "bbm_2",
+        "bbs_2",
+    ]:
         assert col in df.columns
 
     pdt.assert_series_equal(df["sma_2"], expected["sma_2"])
@@ -56,3 +75,6 @@ def test_add_indicator_cache_small_df():
     pdt.assert_series_equal(df["atr_2"], expected["atr_2"])
     pdt.assert_series_equal(df["vol_2"], expected["vol_2"])
     pdt.assert_series_equal(df["impulse_2"], expected["impulse_2"])
+    pdt.assert_series_equal(df["hmax_2"], expected["hmax_2"])
+    pdt.assert_series_equal(df["bbm_2"], expected["bbm_2"])
+    pdt.assert_series_equal(df["bbs_2"], expected["bbs_2"])

--- a/tests/test_indicator_cache_param_space.py
+++ b/tests/test_indicator_cache_param_space.py
@@ -1,0 +1,46 @@
+import pandas as pd
+from trading_backtest.data import add_indicator_cache
+from trading_backtest.optimize import gather_indicator_periods, PARAM_SPACES
+
+
+def _dummy_df(rows: int = 50) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2020-01-01", periods=rows, freq="T"),
+            "open": range(rows),
+            "high": range(1, rows + 1),
+            "low": range(rows),
+            "close": range(rows),
+        }
+    )
+
+
+def test_all_param_space_indicators_exist():
+    df = _dummy_df(60)
+    for name in ["sma", "rsi", "breakout", "bollinger", "momentum", "vol_expansion"]:
+        periods = gather_indicator_periods(name)
+        copy = df.copy()
+        add_indicator_cache(
+            copy,
+            sma=periods.get("sma", []),
+            rsi=periods.get("rsi", []),
+            atr=periods.get("atr", []),
+            vol=periods.get("vol", []),
+            imp=periods.get("imp", []),
+            hmax=periods.get("hmax", []),
+            bb=periods.get("bb", []),
+        )
+        for p in periods.get("sma", []):
+            assert f"sma_{p}" in copy
+        for p in periods.get("rsi", []):
+            assert f"rsi_{p}" in copy
+        for p in periods.get("atr", []):
+            assert f"atr_{p}" in copy
+        for p in periods.get("vol", []):
+            assert f"vol_{p}" in copy
+        for p in periods.get("imp", []):
+            assert f"impulse_{p}" in copy
+        for p in periods.get("hmax", []):
+            assert f"hmax_{p}" in copy
+        for p in periods.get("bb", []):
+            assert f"bbm_{p}" in copy and f"bbs_{p}" in copy

--- a/trading_backtest/__main__.py
+++ b/trading_backtest/__main__.py
@@ -21,6 +21,7 @@ from .utils.io_utils import save_csv
 from .optimize import (
     optimize_with_optuna,
     PARAM_SPACES,
+    gather_indicator_periods,
     prune_sma,
     prune_rsi,
     prune_breakout,
@@ -86,6 +87,7 @@ STRATEGY_REGISTRY = {
     ),
 }
 
+
 def main(with_ml: bool = False) -> None:
     parser = argparse.ArgumentParser(description="Run trading backtest")
     parser.add_argument(
@@ -103,13 +105,16 @@ def main(with_ml: bool = False) -> None:
 
     # 1) Dati + indicatori -------------------------------------------------
     df = load_price_data(DATA_FILE)
+    periods = gather_indicator_periods(strategy_name)
     add_indicator_cache(
         df,
-        sma=list(range(5, 251)) + [300, 400],
-        rsi=[14],
-        atr=[14, 21],
-        vol=[20, 50],
-        imp=[5, 10],
+        sma=periods.get("sma", []),
+        rsi=periods.get("rsi", []),
+        atr=periods.get("atr", []),
+        vol=periods.get("vol", []),
+        imp=periods.get("imp", []),
+        hmax=periods.get("hmax", []),
+        bb=periods.get("bb", []),
     )
 
     # 2) Optuna (modulare!) ------------------------------------------------
@@ -133,7 +138,7 @@ def main(with_ml: bool = False) -> None:
     log.info("Riepilogo strategie salvato in %s", SUMMARY_FILE)
     log.info("=== PERFORMANCE ===\n%s", summary.to_string(index=False))
 
+
 if __name__ == "__main__":
     run_ml = os.getenv("RUN_ML", "0") == "1"
     main(with_ml=run_ml)
-


### PR DESCRIPTION
## Summary
- bulk compute indicators in `add_indicator_cache`
- derive required periods from parameter space with `gather_indicator_periods`
- call caching with computed periods in main pipeline
- test bulk caching and coverage of parameter spaces

## Testing
- `black trading_backtest/data.py trading_backtest/__main__.py trading_backtest/optimize.py tests/test_indicator_cache.py tests/test_indicator_cache_param_space.py`
- `pytest -q` *(fails: SMAConfig.__init__() missing required arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6841aeccd4848323bb9a36ddfda44939