### PR TITLE
[benchmark] add ML toggle

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -8,3 +8,9 @@ def test_benchmark_sorted():
     assert list(result.columns) == ["strategy", "total_return"]
     values = result["total_return"].tolist()
     assert values == sorted(values, reverse=True)
+
+
+def test_benchmark_without_ml():
+    df = _dummy_df()
+    result = benchmark_strategies(df, n_trials=1, with_ml=False)
+    assert "RandomForest" not in result["strategy"].values

--- a/trading_backtest/__main__.py
+++ b/trading_backtest/__main__.py
@@ -134,7 +134,7 @@ def main(with_ml: bool = False) -> None:
         log.info("Grid SMA salvato in %s", RESULTS_FILE)
 
     # 3) Benchmark completo: classiche + ML -------------------------------
-    summary = benchmark_strategies(df, n_trials=25)
+    summary = benchmark_strategies(df, n_trials=25, with_ml=with_ml)
     log.info("Riepilogo strategie salvato in %s", SUMMARY_FILE)
     log.info("=== PERFORMANCE ===\n%s", summary.to_string(index=False))
 

--- a/trading_backtest/benchmark.py
+++ b/trading_backtest/benchmark.py
@@ -35,7 +35,9 @@ from .optimize import (
 from .performance import PerformanceAnalyzer
 
 
-def benchmark_strategies(df: pd.DataFrame, n_trials: int = 50) -> pd.DataFrame:
+def benchmark_strategies(
+    df: pd.DataFrame, n_trials: int = 50, with_ml: bool = True
+) -> pd.DataFrame:
     """Optimize each classical strategy then evaluate on ``df``.
 
     The resulting DataFrame is sorted by ``total_return``.
@@ -85,15 +87,18 @@ def benchmark_strategies(df: pd.DataFrame, n_trials: int = 50) -> pd.DataFrame:
         results.append({"strategy": name, "total_return": ret})
 
     # Machine learning strategy is not optimized here
-    rf_cfg = RandomForestConfig(n_estimators=50, max_depth=None, sl_pct=5, tp_pct=10)
-    rf = RandomForestStrategy(rf_cfg)
-    trades = rf.generate_trades(df)
-    results.append(
-        {
-            "strategy": "RandomForest",
-            "total_return": PerformanceAnalyzer(trades).total_return(),
-        }
-    )
+    if with_ml:
+        rf_cfg = RandomForestConfig(
+            n_estimators=50, max_depth=None, sl_pct=5, tp_pct=10
+        )
+        rf = RandomForestStrategy(rf_cfg)
+        trades = rf.generate_trades(df)
+        results.append(
+            {
+                "strategy": "RandomForest",
+                "total_return": PerformanceAnalyzer(trades).total_return(),
+            }
+        )
 
     summary = pd.DataFrame(results).sort_values("total_return", ascending=False)
     save_csv(summary, SUMMARY_FILE)


### PR DESCRIPTION
## Summary
- allow machine-learning strategy to be toggled in `benchmark_strategies`
- expose the toggle in `main`
- test ML toggle behaviour

## Testing
- `black trading_backtest/__main__.py trading_backtest/benchmark.py tests/test_benchmark.py`
- `pytest -q` *(fails: SMAConfig.__init__ missing required arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6841b211d61c8323a95b6211295a389e