### PR TITLE
[main] add trials and benchmark options

### DIFF
--- a/trading_backtest/benchmark.py
+++ b/trading_backtest/benchmark.py
@@ -36,7 +36,7 @@ from .performance import PerformanceAnalyzer
 
 
 def benchmark_strategies(
-    df: pd.DataFrame, n_trials: int = 50, with_ml: bool = True
+    df: pd.DataFrame, n_trials: int = 300, with_ml: bool = True
 ) -> pd.DataFrame:
     """Optimize each classical strategy then evaluate on ``df``.
 
@@ -81,9 +81,12 @@ def benchmark_strategies(
         trial = optimize_with_optuna(
             df, cls, cfg_cls, space, prune_logic=prune, n_trials=n_trials
         )
-        cfg = cfg_cls(**trial.params)
-        trades = cls(cfg).generate_trades(df)
-        ret = PerformanceAnalyzer(trades).total_return()
+        try:
+            cfg = cfg_cls(**trial.params)
+            trades = cls(cfg).generate_trades(df)
+            ret = PerformanceAnalyzer(trades).total_return()
+        except ValueError:
+            ret = 0.0
         results.append({"strategy": name, "total_return": ret})
 
     # Machine learning strategy is not optimized here


### PR DESCRIPTION
## Summary
- extend CLI with `--trials` and `--benchmark`
- skip strategy optimisation when benchmarking
- pass parsed trials to optuna
- expose `n_trials` control in benchmark
- handle invalid trials gracefully

## Testing
- `black trading_backtest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bc64807483239172409a210b4e6b