### PR TITLE
[benchmark] remove trial constants

### DIFF
--- a/trading_backtest/__main__.py
+++ b/trading_backtest/__main__.py
@@ -95,7 +95,15 @@ def main(with_ml: bool = False) -> None:
         choices=list(STRATEGY_REGISTRY.keys()),
         help="Strategy name to optimize (overrides STRATEGY env var)",
     )
+    parser.add_argument(
+        "--n-trials",
+        type=int,
+        default=int(os.getenv("N_TRIALS", "50")),
+        help="Number of Optuna trials for each optimization",
+    )
     args = parser.parse_args()
+
+    n_trials = args.n_trials
 
     strategy_name = args.strategy or os.getenv("STRATEGY", "sma")
     if strategy_name not in STRATEGY_REGISTRY:
@@ -124,7 +132,7 @@ def main(with_ml: bool = False) -> None:
         config_cls,
         param_space,
         prune_logic=prune_func,
-        n_trials=300,
+        n_trials=n_trials,
     )
 
     if strategy_name == "sma":
@@ -134,7 +142,7 @@ def main(with_ml: bool = False) -> None:
         log.info("Grid SMA salvato in %s", RESULTS_FILE)
 
     # 3) Benchmark completo: classiche + ML -------------------------------
-    summary = benchmark_strategies(df, n_trials=25, with_ml=with_ml)
+    summary = benchmark_strategies(df, n_trials=n_trials, with_ml=with_ml)
     log.info("Riepilogo strategie salvato in %s", SUMMARY_FILE)
     log.info("=== PERFORMANCE ===\n%s", summary.to_string(index=False))
 

--- a/trading_backtest/benchmark.py
+++ b/trading_backtest/benchmark.py
@@ -40,7 +40,21 @@ def benchmark_strategies(
 ) -> pd.DataFrame:
     """Optimize each classical strategy then evaluate on ``df``.
 
-    The resulting DataFrame is sorted by ``total_return``.
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Price data used for generating trades.
+    n_trials : int, default 50
+        Number of Optuna trials used for each strategy.  The caller should
+        explicitly pass this value so all optimizations share the same trial
+        count.
+    with_ml : bool, default True
+        Whether to include the machine learning strategy in the benchmark.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Summary of strategy performance sorted by ``total_return``.
     """
 
     configs = [


### PR DESCRIPTION
## Summary
- document that `benchmark_strategies` expects the caller to pass `n_trials`
- parse `--n-trials` in CLI and use this everywhere

## Testing
- `black trading_backtest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841bc6e3df88323ac52832edaad91e6