### PR TITLE
[docs] update CLI documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,18 @@ python run.py --strategy rsi
 STRATEGY=breakout python run.py
 ```
 
+You can control how many Optuna trials are executed with `--trials` or the
+`TRIALS` environment variable. Use `--benchmark` (or `BENCHMARK=1`) to run a
+short optimization for all supported strategies instead of a single one.
+
+```bash
+# optimize only the RSI strategy with 100 trials
+python run.py --strategy rsi --trials 100
+
+# run the benchmark across all strategies
+python run.py --benchmark
+# or via environment variable
+BENCHMARK=1 python run.py
+```
+
 


### PR DESCRIPTION
## Summary
- document `--trials`/`TRIALS` option for Optuna
- document `--benchmark` and the corresponding `BENCHMARK` environment variable
- show example commands for single strategy optimization and benchmarking

## Testing
- `black trading_backtest`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6841bc75711c832394a7049edcb08204