### PR TITLE
[strategy] add debug logs

### DIFF
--- a/trading_backtest/strategy/base.py
+++ b/trading_backtest/strategy/base.py
@@ -52,6 +52,7 @@ class BaseStrategy(ABC):
 
     # ---------------- motore trades ----------------------
     def generate_trades(self, df: pd.DataFrame) -> pd.DataFrame:
+        print(f"[DEBUG] Config: {self.config}")
         df = self.prepare_indicators(df.copy())
         entries = self.entry_signal(df).fillna(False)
         exits = self.exit_signal(df).fillna(False)
@@ -95,7 +96,11 @@ class BaseStrategy(ABC):
                     qty=qty,
                 )
             )
-        return pd.DataFrame([t.as_dict() for t in trades])
+        trades_df = pd.DataFrame([t.as_dict() for t in trades])
+        print(f"[DEBUG] Numero trade generati: {len(trades_df)}")
+        if not trades_df.empty:
+            print(trades_df.head(3))
+        return trades_df
 
     # ---------------- metodi interni ----------------------
     def _open_trade(

--- a/trading_backtest/strategy/bollinger.py
+++ b/trading_backtest/strategy/bollinger.py
@@ -16,6 +16,10 @@ class BollingerBandStrategy(BaseStrategy):
         if ma not in df:
             df[ma] = df["close"].rolling(self.config.period).mean().shift(1)
             df[sd] = df["close"].rolling(self.config.period).std().shift(1)
+        if df[ma].isna().all() or df[sd].isna().all():
+            print(f"[DEBUG] Colonne {ma}/{sd} contengono solo NaN!")
+        else:
+            print(f"[DEBUG] Bollinger {ma} OK. Stats:\n{df[ma].describe()}")
         df["ma"] = df[ma]
         df["lb"] = df[ma] - self.config.nstd * df[sd]
         return df

--- a/trading_backtest/strategy/breakout.py
+++ b/trading_backtest/strategy/breakout.py
@@ -15,7 +15,14 @@ class BreakoutStrategy(BaseStrategy):
         if h_col not in df:
             df[h_col] = df["close"].shift(1).rolling(self.config.lookback).max()
         df["h"] = df[h_col]
-        df["atr"] = df[f"atr_{self.config.atr_period}"]
+        atr_col = f"atr_{self.config.atr_period}"
+        if atr_col not in df.columns:
+            raise KeyError(f"Colonna {atr_col} mancante")
+        if df[atr_col].isna().all():
+            print(f"[DEBUG] Colonna {atr_col} tutta NaN!")
+        else:
+            print(f"[DEBUG] Colonna {atr_col} OK. Stats:\n{df[atr_col].describe()}")
+        df["atr"] = df[atr_col]
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:

--- a/trading_backtest/strategy/macd.py
+++ b/trading_backtest/strategy/macd.py
@@ -17,6 +17,9 @@ class MACDStrategy(BaseStrategy):
         df["signal"] = (
             df["macd"].ewm(span=self.config.signal, adjust=False).mean().shift(1)
         )
+        print(
+            f"[DEBUG] MACD fast={self.config.fast}, slow={self.config.slow}, signal={self.config.signal}"
+        )
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:

--- a/trading_backtest/strategy/momentum.py
+++ b/trading_backtest/strategy/momentum.py
@@ -11,7 +11,14 @@ class VolatilityExpansionStrategy(BaseStrategy):
         self.config = config
 
     def prepare_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
-        df["v"] = df[f"vol_{self.config.vol_window}"]
+        col = f"vol_{self.config.vol_window}"
+        if col not in df.columns:
+            raise KeyError(f"Colonna {col} mancante")
+        if df[col].isna().all():
+            print(f"[DEBUG] Colonna {col} tutta NaN!")
+        else:
+            print(f"[DEBUG] Colonna {col} OK. Stats:\n{df[col].describe()}")
+        df["v"] = df[col]
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:
@@ -29,7 +36,14 @@ class MomentumImpulseStrategy(BaseStrategy):
         self.config = config
 
     def prepare_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
-        df["imp"] = df[f"impulse_{self.config.window}"]
+        col = f"impulse_{self.config.window}"
+        if col not in df.columns:
+            raise KeyError(f"Colonna {col} mancante")
+        if df[col].isna().all():
+            print(f"[DEBUG] Colonna {col} tutta NaN!")
+        else:
+            print(f"[DEBUG] Colonna {col} OK. Stats:\n{df[col].describe()}")
+        df["imp"] = df[col]
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:

--- a/trading_backtest/strategy/random_forest.py
+++ b/trading_backtest/strategy/random_forest.py
@@ -31,6 +31,7 @@ class RandomForestStrategy(BaseStrategy):
             feature_cols = ["ret_1"]
 
         X = df[feature_cols].fillna(method="bfill").fillna(method="ffill").fillna(0)
+        print(f"[DEBUG] RandomForest feature cols: {feature_cols}")
         y = (df["close"].shift(-1) > df["close"]).astype(int)
 
         split = int(len(df) * 0.7)
@@ -42,6 +43,9 @@ class RandomForestStrategy(BaseStrategy):
             df["rf_prob"] = prob_col
         else:
             df["rf_prob"] = 0.0
+        print(
+            f"[DEBUG] RF params n_estimators={self.config.n_estimators}, max_depth={self.config.max_depth}"
+        )
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:

--- a/trading_backtest/strategy/rsi.py
+++ b/trading_backtest/strategy/rsi.py
@@ -11,7 +11,14 @@ class RSIStrategy(BaseStrategy):
         self.config = config
 
     def prepare_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
-        df["r"] = df[f"rsi_{self.config.period}"]
+        col = f"rsi_{self.config.period}"
+        if col not in df.columns:
+            raise KeyError(f"Colonna {col} mancante")
+        if df[col].isna().all():
+            print(f"[DEBUG] Colonna {col} tutta NaN!")
+        else:
+            print(f"[DEBUG] Colonna {col} OK. Stats:\n{df[col].describe()}")
+        df["r"] = df[col]
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:

--- a/trading_backtest/strategy/sma.py
+++ b/trading_backtest/strategy/sma.py
@@ -13,10 +13,28 @@ class SMACrossoverStrategy(BaseStrategy):
         self.config = config
 
     def prepare_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
-        df["f"] = df[f"sma_{self.config.sma_fast}"]
-        df["s"] = df[f"sma_{self.config.sma_slow}"]
+        fast_col = f"sma_{self.config.sma_fast}"
+        slow_col = f"sma_{self.config.sma_slow}"
+        for col in [fast_col, slow_col]:
+            if col not in df.columns:
+                raise KeyError(f"Colonna {col} mancante")
+            if df[col].isna().all():
+                print(f"[DEBUG] Colonna {col} tutta NaN!")
+            else:
+                print(f"[DEBUG] Colonna {col} OK. Stats:\n{df[col].describe()}")
+        df["f"] = df[fast_col]
+        df["s"] = df[slow_col]
         if self.config.sma_trend:
-            df["t"] = df[f"sma_{self.config.sma_trend}"]
+            trend_col = f"sma_{self.config.sma_trend}"
+            if trend_col not in df.columns:
+                raise KeyError(f"Colonna {trend_col} mancante")
+            if df[trend_col].isna().all():
+                print(f"[DEBUG] Colonna {trend_col} tutta NaN!")
+            else:
+                print(
+                    f"[DEBUG] Colonna {trend_col} OK. Stats:\n{df[trend_col].describe()}"
+                )
+            df["t"] = df[trend_col]
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:

--- a/trading_backtest/strategy/stochastic.py
+++ b/trading_backtest/strategy/stochastic.py
@@ -15,6 +15,9 @@ class StochasticStrategy(BaseStrategy):
         high_n = df["high"].rolling(self.config.k_period).max().shift(1)
         df["k"] = (df["close"] - low_n) / (high_n - low_n) * 100
         df["d"] = df["k"].rolling(self.config.d_period).mean().shift(1)
+        print(
+            f"[DEBUG] Stochastic k_period={self.config.k_period}, d_period={self.config.d_period}"
+        )
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:


### PR DESCRIPTION
## Summary
- add diagnostic prints for config, indicator columns, and trade counts
- show basic stats for indicator columns for SMA, RSI and other strategies
- emit config debug log from BaseStrategy
- run manual RSI trial with debugging

## Testing
- `pip install -q pandas numpy optuna tqdm scikit-learn`
- `pytest -q`
- `python - <<'PY'
import pandas as pd
from trading_backtest.data import load_price_data, add_indicator_cache
from trading_backtest.config import DATA_FILE, RSIConfig
from trading_backtest.strategy.rsi import RSIStrategy

df = load_price_data(DATA_FILE)
add_indicator_cache(df, rsi=[14])
cfg = RSIConfig(period=14, oversold=30, sl_pct=5, tp_pct=10)
strat = RSIStrategy(cfg)
trades = strat.generate_trades(df)
print(trades)
PY

------
https://chatgpt.com/codex/tasks/task_e_6841bffb1b948323ab6985570e923005