### PR TITLE
[main] benchmark indicator caching

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,3 +1,8 @@
+import os
+import sys
+import subprocess
+import pandas as pd
+
 from trading_backtest.benchmark import benchmark_strategies
 from tests.test_optuna_param_spaces import _dummy_df
 
@@ -14,3 +19,32 @@ def test_benchmark_without_ml():
     df = _dummy_df()
     result = benchmark_strategies(df, n_trials=1, with_ml=False)
     assert "RandomForest" not in result["strategy"].values
+
+
+def test_cli_benchmark_runs(tmp_path):
+    df = pd.DataFrame(
+        {
+            "Open time": pd.date_range("2020-01-01", periods=50, freq="T"),
+            "Open": range(50),
+            "High": range(1, 51),
+            "Low": range(50),
+            "Close": range(50),
+            "Volume": range(50),
+        }
+    )
+    csv = tmp_path / "data.csv"
+    df.to_csv(csv, index=False)
+
+    env = os.environ.copy()
+    env.update({"DATA_FILE": str(csv), "RUN_ML": "0"})
+
+    res = subprocess.run(
+        [sys.executable, "-m", "trading_backtest", "--benchmark", "--trials", "1"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert res.returncode == 0
+    assert "KeyError" not in res.stderr

--- a/trading_backtest/__main__.py
+++ b/trading_backtest/__main__.py
@@ -119,7 +119,26 @@ def main(with_ml: bool = False) -> None:
 
     # 1) Dati + indicatori -------------------------------------------------
     df = load_price_data(DATA_FILE)
-    periods = gather_indicator_periods(strategy_name)
+    if args.benchmark:
+        merged: dict[str, set[int]] = {
+            "sma": set(),
+            "rsi": set(),
+            "atr": set(),
+            "vol": set(),
+            "imp": set(),
+            "hmax": set(),
+            "bb": set(),
+        }
+        for name in STRATEGY_REGISTRY:
+            if name not in PARAM_SPACES:
+                continue
+            periods = gather_indicator_periods(name)
+            for k, vals in periods.items():
+                merged[k].update(vals)
+        periods = {k: sorted(v) for k, v in merged.items() if v}
+    else:
+        periods = gather_indicator_periods(strategy_name)
+
     add_indicator_cache(
         df,
         sma=periods.get("sma", []),
@@ -158,4 +177,3 @@ def main(with_ml: bool = False) -> None:
 if __name__ == "__main__":
     run_ml = os.getenv("RUN_ML", "0") == "1"
     main(with_ml=run_ml)
-


### PR DESCRIPTION
## Summary
- cache indicators for all strategies when `--benchmark` mode is used
- test CLI benchmark flow on a clean dataframe

## Testing
- `black trading_backtest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841e1fac16c8323b23d8e7767cb166c