### PR TITLE
[strategy] remove stray codex instruction

### DIFF
--- a/trading_backtest/strategy/random_forest.py
+++ b/trading_backtest/strategy/random_forest.py
@@ -30,7 +30,6 @@ class RandomForestStrategy(BaseStrategy):
             df["ret_1"] = df["close"].pct_change().fillna(0)
             feature_cols = ["ret_1"]
 
-        codex/replace-print-with-log.debug-in-strategy-modules
         X = df[feature_cols].fillna(method="bfill").fillna(method="ffill").fillna(0)
         log.debug(f"RandomForest feature cols: {feature_cols}")
 


### PR DESCRIPTION
## Summary
- remove leftover codex instruction line in `RandomForestStrategy`

## Testing
- `black trading_backtest/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6841e4fbf8d0832383e3694402251557