### PR TITLE
[strategy] Backfill volatility data

### DIFF
--- a/tests/test_volatility_expansion_strategy.py
+++ b/tests/test_volatility_expansion_strategy.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import numpy as np
+
+from trading_backtest.strategy.momentum import VolatilityExpansionStrategy
+from trading_backtest.config import VolExpansionConfig
+
+
+def test_prepare_indicators_backfills_nan():
+    df = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2020-01-01", periods=5, freq="T"),
+            "open": np.arange(5),
+            "high": np.arange(5),
+            "low": np.arange(5),
+            "close": np.arange(5),
+            "vol_20": [np.nan, np.nan, 0.6, 0.4, 0.7],
+        }
+    )
+    cfg = VolExpansionConfig(vol_window=20, vol_threshold=0.5, sl_pct=1, tp_pct=2)
+    strat = VolatilityExpansionStrategy(cfg)
+    processed = strat.prepare_indicators(df.copy())
+    assert not processed["v"].isna().any()
+    expected_v = [0.6, 0.6, 0.6, 0.4, 0.7]
+    assert processed["v"].tolist() == expected_v
+
+    entries = strat.entry_signal(processed)
+    exits = strat.exit_signal(processed)
+    assert entries.dtype == bool
+    assert exits.dtype == bool
+    assert not entries.isna().any()
+    assert not exits.isna().any()
+    pd.testing.assert_series_equal(entries, processed["v"] > cfg.vol_threshold)
+    pd.testing.assert_series_equal(exits, processed["v"] < cfg.vol_threshold)

--- a/trading_backtest/strategy/momentum.py
+++ b/trading_backtest/strategy/momentum.py
@@ -18,7 +18,8 @@ class VolatilityExpansionStrategy(BaseStrategy):
             log.debug(f"Colonna {col} tutta NaN!")
         else:
             log.debug(f"Colonna {col} OK. Stats:\n{df[col].describe()}")
-        df["v"] = df[col]
+        v = df[col].bfill().ffill()
+        df["v"] = v
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:


### PR DESCRIPTION
## Summary
- fill NaN values in `VolatilityExpansionStrategy.prepare_indicators`
- add regression test covering NaN handling for volatility strategy

## Testing
- `black trading_backtest`
- `black tests/test_volatility_expansion_strategy.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bdbfbbbc8323af98fa8809f7b6a3