### PR TITLE
[data] Enhanced RSI calculation

### DIFF
--- a/tests/test_indicator_cache.py
+++ b/tests/test_indicator_cache.py
@@ -25,8 +25,12 @@ def test_add_indicator_cache_small_df():
     # RSI
     delta = expected["close"].diff()
     up, down = delta.clip(lower=0), -delta.clip(upper=0)
-    rs = up.rolling(w).mean() / down.replace(0, np.nan).rolling(w).mean()
-    expected[f"rsi_{w}"] = (100 - 100 / (1 + rs)).shift(1)
+    gain = up.rolling(w, min_periods=1).mean()
+    loss = down.rolling(w, min_periods=1).mean()
+    rs = gain / loss.replace(0, np.nan)
+    rsi_vals = 100 - 100 / (1 + rs)
+    rsi_vals = rsi_vals.bfill()
+    expected[f"rsi_{w}"] = rsi_vals.shift(1)
 
     # ATR and true range
     tr = np.maximum(


### PR DESCRIPTION
## Summary
- refine RSI computation in `add_indicator_cache` to reduce leading NaNs
- update indicator cache tests for new RSI logic

## Testing
- `black trading_backtest tests/test_indicator_cache.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bdc07a60832389965bd80280daca