### PR TITLE
[optimize] add RandomForest param space

### DIFF
--- a/tests/test_optuna_param_spaces.py
+++ b/tests/test_optuna_param_spaces.py
@@ -13,6 +13,7 @@ from trading_backtest.optimize import (
     prune_vol_expansion,
     prune_macd,
     prune_stochastic,
+    prune_random_forest,
     SMAParamSpace,
     RSIParamSpace,
     BreakoutParamSpace,
@@ -21,6 +22,7 @@ from trading_backtest.optimize import (
     VolExpansionParamSpace,
     MACDParamSpace,
     StochasticParamSpace,
+    RandomForestParamSpace,
     check_sl_tp,
 )
 from trading_backtest.strategy import get_strategy
@@ -33,6 +35,7 @@ from trading_backtest.config import (
     VolExpansionConfig,
     MACDConfig,
     StochasticConfig,
+    RandomForestConfig,
 )
 
 
@@ -126,6 +129,12 @@ def test_optimize_instantiates_strategies():
         ),
         ("macd", MACDConfig, MACDParamSpace(), prune_macd),
         ("stochastic", StochasticConfig, StochasticParamSpace(), prune_stochastic),
+        (
+            "random_forest",
+            RandomForestConfig,
+            RandomForestParamSpace(),
+            prune_random_forest,
+        ),
     ]
     for name, cfg_cls, space, prune in configs:
         strategy_cls, _ = get_strategy(name)

--- a/trading_backtest/__main__.py
+++ b/trading_backtest/__main__.py
@@ -28,6 +28,7 @@ from .optimize import (
     prune_bollinger,
     prune_momentum,
     prune_vol_expansion,
+    prune_random_forest,
     refined_sma_grid,
     grid_search,
     ensure_indicator_cache,
@@ -83,8 +84,8 @@ STRATEGY_REGISTRY = {
     "random_forest": (
         RandomForestStrategy,
         RandomForestConfig,
-        PARAM_SPACES.get("random_forest", {}),
-        lambda params: None,  # Prune function dummy per ML, aggiorna se ne hai una
+        PARAM_SPACES["random_forest"],
+        prune_random_forest,
     ),
 }
 

--- a/trading_backtest/optimize.py
+++ b/trading_backtest/optimize.py
@@ -18,6 +18,7 @@ from .config import (
     VolExpansionConfig,
     MACDConfig,
     StochasticConfig,
+    RandomForestConfig,
 )
 
 
@@ -103,6 +104,16 @@ class StochasticParamSpace(ParamSpace):
     tp_pct: tuple = ("int", 10, 25, 5)
 
 
+@dataclass
+class RandomForestParamSpace(ParamSpace):
+    n_estimators: tuple = ("int", 10, 50, 10)
+    max_depth: tuple = ("cat", [None, 3, 5, 7, 9])
+    entry_threshold: tuple = ("float", 0.5, 0.7, 0.05)
+    exit_threshold: tuple = ("float", 0.3, 0.5, 0.05)
+    sl_pct: tuple = ("int", 5, 10)
+    tp_pct: tuple = ("int", 10, 25, 5)
+
+
 # ---------------------- PARAMETRI STRATEGIE --------------------------
 PARAM_SPACES = {
     "sma": SMAParamSpace(),
@@ -113,6 +124,7 @@ PARAM_SPACES = {
     "vol_expansion": VolExpansionParamSpace(),
     "macd": MACDParamSpace(),
     "stochastic": StochasticParamSpace(),
+    "random_forest": RandomForestParamSpace(),
 }
 
 
@@ -378,6 +390,13 @@ def prune_stochastic(params, trial):
     """Prune stochastic trials with invalid stop or period setup."""
     check_sl_tp(params)
     if params["d_period"] > params["k_period"]:
+        raise optuna.TrialPruned()
+
+
+def prune_random_forest(params, trial):
+    """Prune RandomForest trials with invalid thresholds or stop settings."""
+    check_sl_tp(params)
+    if params["entry_threshold"] <= params["exit_threshold"]:
         raise optuna.TrialPruned()
 
 


### PR DESCRIPTION
## Summary
- support RandomForest hyperparameters in optimize module
- handle pruning for RandomForest trials
- update CLI to use the new param space
- test optimization works with RandomForest

## Testing
- `black trading_backtest tests`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bdc0fdc88323b48abbd73630606f