### PR TITLE
[strategy] centralize column validation

### DIFF
--- a/trading_backtest/strategy/bollinger.py
+++ b/trading_backtest/strategy/bollinger.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from .base import BaseStrategy
-from ..config import BollingerConfig, log
+from ..config import BollingerConfig
+from ..utils import validate_column
 
 
 class BollingerBandStrategy(BaseStrategy):
@@ -16,10 +17,8 @@ class BollingerBandStrategy(BaseStrategy):
         if ma not in df:
             df[ma] = df["close"].rolling(self.config.period).mean().shift(1)
             df[sd] = df["close"].rolling(self.config.period).std().shift(1)
-        if df[ma].isna().all() or df[sd].isna().all():
-            log.debug(f"Colonne {ma}/{sd} contengono solo NaN!")
-        else:
-            log.debug(f"Bollinger {ma} OK. Stats:\n{df[ma].describe()}")
+        validate_column(df, ma)
+        validate_column(df, sd)
         df["ma"] = df[ma]
         df["lb"] = df[ma] - self.config.nstd * df[sd]
         return df

--- a/trading_backtest/strategy/breakout.py
+++ b/trading_backtest/strategy/breakout.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from .base import BaseStrategy
-from ..config import BreakoutConfig, log
+from ..config import BreakoutConfig
+from ..utils import validate_column
 
 
 class BreakoutStrategy(BaseStrategy):
@@ -16,13 +17,7 @@ class BreakoutStrategy(BaseStrategy):
             df[h_col] = df["close"].shift(1).rolling(self.config.lookback).max()
         df["h"] = df[h_col]
         atr_col = f"atr_{self.config.atr_period}"
-        if atr_col not in df.columns:
-            raise KeyError(f"Colonna {atr_col} mancante")
-        if df[atr_col].isna().all():
-            log.debug(f"Colonna {atr_col} tutta NaN!")
-        else:
-            log.debug(f"Colonna {atr_col} OK. Stats:\n{df[atr_col].describe()}")
-        df["atr"] = df[atr_col]
+        df["atr"] = validate_column(df, atr_col)
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:

--- a/trading_backtest/strategy/momentum.py
+++ b/trading_backtest/strategy/momentum.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from .base import BaseStrategy
-from ..config import MomentumConfig, VolExpansionConfig, log
+from ..config import MomentumConfig, VolExpansionConfig
+from ..utils import validate_column
 
 
 class VolatilityExpansionStrategy(BaseStrategy):
@@ -12,13 +13,7 @@ class VolatilityExpansionStrategy(BaseStrategy):
 
     def prepare_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
         col = f"vol_{self.config.vol_window}"
-        if col not in df.columns:
-            raise KeyError(f"Colonna {col} mancante")
-        if df[col].isna().all():
-            log.debug(f"Colonna {col} tutta NaN!")
-        else:
-            log.debug(f"Colonna {col} OK. Stats:\n{df[col].describe()}")
-        df["v"] = df[col]
+        df["v"] = validate_column(df, col)
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:
@@ -37,13 +32,7 @@ class MomentumImpulseStrategy(BaseStrategy):
 
     def prepare_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
         col = f"impulse_{self.config.window}"
-        if col not in df.columns:
-            raise KeyError(f"Colonna {col} mancante")
-        if df[col].isna().all():
-            log.debug(f"Colonna {col} tutta NaN!")
-        else:
-            log.debug(f"Colonna {col} OK. Stats:\n{df[col].describe()}")
-        df["imp"] = df[col]
+        df["imp"] = validate_column(df, col)
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:

--- a/trading_backtest/strategy/rsi.py
+++ b/trading_backtest/strategy/rsi.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from .base import BaseStrategy
-from ..config import RSIConfig, log
+from ..config import RSIConfig
+from ..utils import validate_column
 
 
 class RSIStrategy(BaseStrategy):
@@ -12,13 +13,7 @@ class RSIStrategy(BaseStrategy):
 
     def prepare_indicators(self, df: pd.DataFrame) -> pd.DataFrame:
         col = f"rsi_{self.config.period}"
-        if col not in df.columns:
-            raise KeyError(f"Colonna {col} mancante")
-        if df[col].isna().all():
-            log.debug(f"Colonna {col} tutta NaN!")
-        else:
-            log.debug(f"Colonna {col} OK. Stats:\n{df[col].describe()}")
-        df["r"] = df[col]
+        df["r"] = validate_column(df, col)
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:

--- a/trading_backtest/strategy/sma.py
+++ b/trading_backtest/strategy/sma.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 import pandas as pd
 from .base import BaseStrategy
-from ..config import SMAConfig, log
+from ..config import SMAConfig
+from ..utils import validate_column
 
 
 class SMACrossoverStrategy(BaseStrategy):
@@ -16,23 +17,12 @@ class SMACrossoverStrategy(BaseStrategy):
         fast_col = f"sma_{self.config.sma_fast}"
         slow_col = f"sma_{self.config.sma_slow}"
         for col in [fast_col, slow_col]:
-            if col not in df.columns:
-                raise KeyError(f"Colonna {col} mancante")
-            if df[col].isna().all():
-                log.debug(f"Colonna {col} tutta NaN!")
-            else:
-                log.debug(f"Colonna {col} OK. Stats:\n{df[col].describe()}")
+            validate_column(df, col)
         df["f"] = df[fast_col]
         df["s"] = df[slow_col]
         if self.config.sma_trend:
             trend_col = f"sma_{self.config.sma_trend}"
-            if trend_col not in df.columns:
-                raise KeyError(f"Colonna {trend_col} mancante")
-            if df[trend_col].isna().all():
-                log.debug(f"Colonna {trend_col} tutta NaN!")
-            else:
-                log.debug(f"Colonna {trend_col} OK. Stats:\n{df[trend_col].describe()}")
-            df["t"] = df[trend_col]
+            df["t"] = validate_column(df, trend_col)
         return df
 
     def entry_signal(self, df: pd.DataFrame) -> pd.Series:

--- a/trading_backtest/utils/__init__.py
+++ b/trading_backtest/utils/__init__.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+import pandas as pd
+
+from ..config import log
+
+
+def validate_column(df: pd.DataFrame, col: str) -> pd.Series:
+    """Ensure column exists and log NaN stats."""
+    if col not in df.columns:
+        raise KeyError(f"Colonna {col} mancante")
+    series = df[col]
+    if series.isna().all():
+        log.debug(f"Colonna {col} tutta NaN!")
+    else:
+        log.debug(f"Colonna {col} OK. Stats:\n{series.describe()}")
+    return series
+
+
+__all__ = ["validate_column"]


### PR DESCRIPTION
## Summary
- add `validate_column` helper in utils
- utilize helper across strategy implementations

## Testing
- `black trading_backtest`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6842bdc1e4648323ae37b95654fa0f37