### PR TITLE
[optimize] support sharpe score

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -10,8 +10,8 @@ from tests.test_optuna_param_spaces import _dummy_df
 def test_benchmark_sorted():
     df = _dummy_df()
     result = benchmark_strategies(df, n_trials=1)
-    assert list(result.columns) == ["strategy", "total_return"]
-    values = result["total_return"].tolist()
+    assert list(result.columns) == ["strategy", "score"]
+    values = result["score"].tolist()
     assert values == sorted(values, reverse=True)
 
 

--- a/tests/test_evaluate_strategy.py
+++ b/tests/test_evaluate_strategy.py
@@ -1,0 +1,26 @@
+import pytest
+from trading_backtest.optimize import evaluate_strategy
+from trading_backtest.strategy import get_strategy
+from trading_backtest.config import SMAConfig
+from trading_backtest.performance import PerformanceAnalyzer
+from tests.test_optuna_param_spaces import _dummy_df
+
+
+def test_evaluate_strategy_with_sharpe():
+    df = _dummy_df()
+    strategy_cls, _ = get_strategy("sma")
+    cfg = SMAConfig(
+        sma_fast=5,
+        sma_slow=10,
+        sma_trend=None,
+        sl_pct=1,
+        tp_pct=2,
+        position_size=1,
+        trailing_stop_pct=1,
+    )
+    score = evaluate_strategy(df, lambda: strategy_cls(cfg), with_sharpe=True)
+
+    trades = strategy_cls(cfg).generate_trades(df)
+    pa = PerformanceAnalyzer(trades, commission=0.1, slippage=0.05)
+    expected = pa.total_return() + pa.sharpe_ratio()
+    assert score == pytest.approx(expected)

--- a/trading_backtest/optimize.py
+++ b/trading_backtest/optimize.py
@@ -382,12 +382,27 @@ def prune_stochastic(params, trial):
 
 
 # ---------------------- STRATEGY EVALUATION -----------------------------
-def evaluate_strategy(df: pd.DataFrame, make_strategy: Callable[[], Any]) -> float:
-    """Return the total strategy return for the given dataframe."""
+def evaluate_strategy(
+    df: pd.DataFrame,
+    make_strategy: Callable[[], Any],
+    *,
+    with_sharpe: bool = False,
+) -> float:
+    """Return a score for the given strategy on ``df``.
+
+    When ``with_sharpe`` is ``True`` the score is the sum of the total return
+    and the Sharpe ratio computed by :class:`PerformanceAnalyzer`.  This can be
+    useful during optimization to favour strategies with a better risk/return
+    profile while remaining backward compatible when the flag is ``False``.
+    """
 
     strat = make_strategy()
     trades = strat.generate_trades(df)
-    return PerformanceAnalyzer(trades, commission=0.1, slippage=0.05).total_return()
+    pa = PerformanceAnalyzer(trades, commission=0.1, slippage=0.05)
+    score = pa.total_return()
+    if with_sharpe:
+        score += pa.sharpe_ratio()
+    return score
 
 
 # ---------------------- OBJECTIVE GENERICO ---------------------------


### PR DESCRIPTION
## Summary
- extend `evaluate_strategy` with optional Sharpe component
- rank benchmark strategies using the combined score
- update tests for new metric
- add dedicated test for `evaluate_strategy`

## Testing
- `black trading_backtest/ tests/`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bdc2c6808323bc42152031a5b7c5