### PR TITLE
[optimize] validate rsi and bollinger params

### DIFF
--- a/tests/test_optuna_param_spaces.py
+++ b/tests/test_optuna_param_spaces.py
@@ -138,3 +138,21 @@ def test_check_sl_tp_pruning():
     check_sl_tp({"sl_pct": 5, "tp_pct": 10})
     with pytest.raises(optuna.TrialPruned):
         check_sl_tp({"sl_pct": 10, "tp_pct": 5})
+
+
+def test_prune_rsi_parameters():
+    """RSI oversold must be within 0–50."""
+    params = {"period": 14, "oversold": 30, "sl_pct": 1, "tp_pct": 2}
+    prune_rsi(params, None)  # Should not raise
+    params["oversold"] = 60
+    with pytest.raises(optuna.TrialPruned):
+        prune_rsi(params, None)
+
+
+def test_prune_bollinger_parameters():
+    """Bollinger nstd must be positive."""
+    params = {"period": 20, "nstd": 2.0, "sl_pct": 1, "tp_pct": 2}
+    prune_bollinger(params, None)  # Should not raise
+    params["nstd"] = -1
+    with pytest.raises(optuna.TrialPruned):
+        prune_bollinger(params, None)

--- a/trading_backtest/optimize.py
+++ b/trading_backtest/optimize.py
@@ -343,8 +343,16 @@ def prune_sma(params, trial):
 
 
 def prune_rsi(params, trial):
-    """Prune RSI trials with invalid stop or take-profit."""
+    """Prune RSI trials with invalid parameters.
+
+    Besides stop/take-profit checks, ensure ``oversold`` stays within
+    a sensible range (0–50) and the period is positive.
+    """
     check_sl_tp(params)
+    if not (0 <= params["oversold"] <= 50):
+        raise optuna.TrialPruned()
+    if params["period"] <= 0:
+        raise optuna.TrialPruned()
 
 
 def prune_breakout(params, trial):
@@ -353,8 +361,12 @@ def prune_breakout(params, trial):
 
 
 def prune_bollinger(params, trial):
-    """Prune Bollinger trials with invalid stop or take-profit."""
+    """Prune Bollinger trials with invalid parameters."""
     check_sl_tp(params)
+    if params["nstd"] <= 0:
+        raise optuna.TrialPruned()
+    if params["period"] <= 0:
+        raise optuna.TrialPruned()
 
 
 def prune_momentum(params, trial):


### PR DESCRIPTION
## Summary
- add parameter checks to `prune_rsi` and `prune_bollinger`
- test new pruning logic

## Testing
- `black trading_backtest/ tests/test_optuna_param_spaces.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842bdc3a42c8323964d81d9f275b902