### PR TITLE
Add AGENTS and rewrite README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# Contributor Guidelines
+
+This project uses Python. When updating the codebase, please:
+
+1. Install dependencies with `pip install -r requirements.txt` or run `./setup.sh`.
+2. Format any Python files with `black` before committing.
+3. Run the unit tests with `pytest`.
+4. The main entry points are `run.py` or `python -m trading_backtest`.
+5. Price data is read from the CSV path given by the `DATA_FILE` environment variable. If unset, it defaults to `data/btc_15m_data_from_2021.csv`.


### PR DESCRIPTION
## Summary
- document contribution guidelines in a new `AGENTS.md`
- rewrite the README in Italian with a project overview and usage instructions

## Testing
- `black trading_backtest tests`
- `pytest -q` *(fails: NameError: name 'log' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6842dc1a1998832390350e1e0d006c38