### PR TITLE
Fix log import in momentum strategy

### DIFF
--- a/trading_backtest/strategy/momentum.py
+++ b/trading_backtest/strategy/momentum.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from .base import BaseStrategy
-from ..config import MomentumConfig, VolExpansionConfig
+from ..config import MomentumConfig, VolExpansionConfig, log
 from ..utils import validate_column
 
 


### PR DESCRIPTION
## Summary
- import `log` from `..config` for momentum strategies
- run formatting via `black`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: tests/test_config.py::test_data_file_default)*

------
https://chatgpt.com/codex/tasks/task_e_6842ef40463483239078797fc84e1d16