### PR TITLE
Update vol expansion threshold range

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,4 +7,4 @@ import trading_backtest.config as cfg
 def test_data_file_default(monkeypatch):
     monkeypatch.delenv("DATA_FILE", raising=False)
     importlib.reload(cfg)
-    assert cfg.DATA_FILE == Path("data/btc_15m_data_2018_to_2025.csv")
+    assert cfg.DATA_FILE == Path("data/btc_15m_sample.csv")

--- a/tests/test_generate_trades.py
+++ b/tests/test_generate_trades.py
@@ -72,7 +72,7 @@ def _dummy_df() -> pd.DataFrame:
         ),
         (
             "vol_expansion",
-            VolExpansionConfig(vol_window=20, vol_threshold=0.4, sl_pct=1, tp_pct=2),
+            VolExpansionConfig(vol_window=20, vol_threshold=0.01, sl_pct=1, tp_pct=2),
         ),
         ("macd", MACDConfig(fast=12, slow=26, signal=9, sl_pct=1, tp_pct=2)),
         (

--- a/tests/test_optuna_param_spaces.py
+++ b/tests/test_optuna_param_spaces.py
@@ -97,7 +97,7 @@ def test_generate_trades_runs():
         ("momentum", MomentumConfig(window=10, threshold=0, sl_pct=1, tp_pct=2)),
         (
             "vol_expansion",
-            VolExpansionConfig(vol_window=20, vol_threshold=0.4, sl_pct=1, tp_pct=2),
+            VolExpansionConfig(vol_window=20, vol_threshold=0.01, sl_pct=1, tp_pct=2),
         ),
         ("macd", MACDConfig(fast=12, slow=26, signal=9, sl_pct=1, tp_pct=2)),
         (

--- a/tests/test_volatility_expansion_strategy.py
+++ b/tests/test_volatility_expansion_strategy.py
@@ -16,7 +16,7 @@ def test_prepare_indicators_backfills_nan():
             "vol_20": [np.nan, np.nan, 0.6, 0.4, 0.7],
         }
     )
-    cfg = VolExpansionConfig(vol_window=20, vol_threshold=0.5, sl_pct=1, tp_pct=2)
+    cfg = VolExpansionConfig(vol_window=20, vol_threshold=0.01, sl_pct=1, tp_pct=2)
     strat = VolatilityExpansionStrategy(cfg)
     processed = strat.prepare_indicators(df.copy())
     assert not processed["v"].isna().any()

--- a/trading_backtest/optimize.py
+++ b/trading_backtest/optimize.py
@@ -81,7 +81,7 @@ class MomentumParamSpace(ParamSpace):
 @dataclass
 class VolExpansionParamSpace(ParamSpace):
     vol_window: tuple = ("int", 20, 100, 5)
-    vol_threshold: tuple = ("float", 0.6, 1.0, 0.05)
+    vol_threshold: tuple = ("float", 0.005, 0.02, 0.001)
     sl_pct: tuple = ("int", 5, 10)
     tp_pct: tuple = ("int", 10, 25, 5)
 


### PR DESCRIPTION
## Summary
- tune VolExpansionParamSpace.vol_threshold to match indicator scale
- adjust unit tests for new volatility threshold range
- fix DATA_FILE path expectation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f5293d308323bc0ea3c6b45c760f