### PR TITLE
Implement refined grid search across strategies

### DIFF
--- a/tests/test_grid_search_generic.py
+++ b/tests/test_grid_search_generic.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+import pandas as pd
+from trading_backtest.optimize import grid_search
+from tests.test_optuna_param_spaces import _dummy_df
+
+
+def test_grid_search_rsi_dataframe():
+    df = _dummy_df()
+    combos = [
+        {"period": 14, "oversold": 30, "sl_pct": 5, "tp_pct": 10},
+        {"period": 15, "oversold": 30, "sl_pct": 5, "tp_pct": 10},
+    ]
+    result = grid_search(df, combos, "rsi")
+    assert not result.empty
+    assert "total_return" in result.columns
+    assert len(result) == 2
+
+
+def test_cli_grid_search_rsi_output(tmp_path):
+    df = pd.DataFrame(
+        {
+            "Open time": pd.date_range("2020-01-01", periods=50, freq="T"),
+            "Open": range(50),
+            "High": range(1, 51),
+            "Low": range(50),
+            "Close": range(50),
+            "Volume": range(50),
+        }
+    )
+    csv = tmp_path / "data.csv"
+    df.to_csv(csv, index=False)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "DATA_FILE": str(csv),
+            "PYTHONPATH": str(Path(__file__).resolve().parents[1]),
+        }
+    )
+
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "trading_backtest",
+            "--strategy",
+            "rsi",
+            "--trials",
+            "1",
+        ],
+        env=env,
+        cwd=tmp_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert res.returncode == 0
+    assert "KeyError" not in res.stderr
+    assert (tmp_path / "results_live.csv").is_file()

--- a/trading_backtest/__main__.py
+++ b/trading_backtest/__main__.py
@@ -29,7 +29,7 @@ from .optimize import (
     prune_momentum,
     prune_vol_expansion,
     prune_random_forest,
-    refined_sma_grid,
+    refined_grid,
     grid_search,
     ensure_indicator_cache,
 )
@@ -163,12 +163,11 @@ def main(with_ml: bool = False) -> None:
             n_trials=n_trials,
         )
 
-        if strategy_name == "sma":
-            sma_grid = refined_sma_grid(best_trial.params)
-            ensure_indicator_cache(df, sma_grid)
-            grid_df = grid_search(df, sma_grid)
-            save_csv(grid_df, RESULTS_FILE)
-            log.info("Grid SMA salvato in %s", RESULTS_FILE)
+        grid = refined_grid(strategy_name, best_trial.params)
+        ensure_indicator_cache(df, grid)
+        grid_df = grid_search(df, grid, strategy_name)
+        save_csv(grid_df, RESULTS_FILE)
+        log.info("Grid %s salvato in %s", strategy_name.upper(), RESULTS_FILE)
 
     # 3) Benchmark completo: classiche + ML -------------------------------
     if args.benchmark:

--- a/trading_backtest/config.py
+++ b/trading_backtest/config.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 # Usa variabile d'ambiente se disponibile, altrimenti path relativo al progetto
-DATA_FILE = Path(os.environ.get("DATA_FILE", "data/btc_15m_data_from_2021.csv"))
+DATA_FILE = Path(os.environ.get("DATA_FILE", "data/btc_15m_sample.csv"))
 RESULTS_FILE = Path("results_live.csv")
 SUMMARY_FILE = Path("summary_live.csv")
 


### PR DESCRIPTION
## Summary
- create `refined_grid` supporting every strategy
- extend `grid_search` to accept a strategy name
- call `refined_grid` from CLI and always store results
- default DATA_FILE to sample dataset
- test generic grid search and CLI output for RSI

## Testing
- `pip install -r requirements.txt`
- `black trading_backtest tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f875d80c83238434744f0cef9ebb