### PR TITLE
Save Optuna best params to csv

### DIFF
--- a/tests/test_cli_best_params.py
+++ b/tests/test_cli_best_params.py
@@ -1,0 +1,48 @@
+import os
+import sys
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+
+
+def test_cli_best_params_saved(tmp_path):
+    df = pd.DataFrame(
+        {
+            "Open time": pd.date_range("2020-01-01", periods=50, freq="T"),
+            "Open": range(50),
+            "High": range(1, 51),
+            "Low": range(50),
+            "Close": range(50),
+            "Volume": range(50),
+        }
+    )
+    csv = tmp_path / "data.csv"
+    df.to_csv(csv, index=False)
+
+    env = os.environ.copy()
+    env["DATA_FILE"] = str(csv)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "trading_backtest",
+            "--strategy",
+            "sma",
+            "--trials",
+            "1",
+        ],
+        env=env,
+        cwd=tmp_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    assert res.returncode == 0
+    best_file = tmp_path / "best_params.csv"
+    assert best_file.exists()
+    saved = pd.read_csv(best_file)
+    assert list(saved["strategy"]) == ["sma"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,4 +7,4 @@ import trading_backtest.config as cfg
 def test_data_file_default(monkeypatch):
     monkeypatch.delenv("DATA_FILE", raising=False)
     importlib.reload(cfg)
-    assert cfg.DATA_FILE == Path("data/btc_15m_sample.csv")
+    assert cfg.DATA_FILE == Path("data/btc_15m_data_from_2021.csv")

--- a/trading_backtest/__main__.py
+++ b/trading_backtest/__main__.py
@@ -7,6 +7,7 @@ from .config import (
     RESULTS_FILE,
     SUMMARY_FILE,
     DATA_FILE,
+    BEST_PARAMS_FILE,
     log,
     SMAConfig,
     RSIConfig,
@@ -17,7 +18,7 @@ from .config import (
     RandomForestConfig,
 )
 from .data import load_price_data, add_indicator_cache
-from .utils.io_utils import save_csv
+from .utils.io_utils import save_csv, save_best_params
 from .optimize import (
     optimize_with_optuna,
     PARAM_SPACES,
@@ -162,6 +163,8 @@ def main(with_ml: bool = False) -> None:
             prune_logic=prune_func,
             n_trials=n_trials,
         )
+
+        save_best_params(best_trial.params, strategy_name, BEST_PARAMS_FILE)
 
         if strategy_name == "sma":
             sma_grid = refined_sma_grid(best_trial.params)

--- a/trading_backtest/config.py
+++ b/trading_backtest/config.py
@@ -8,6 +8,7 @@ from typing import Optional
 DATA_FILE = Path(os.environ.get("DATA_FILE", "data/btc_15m_data_from_2021.csv"))
 RESULTS_FILE = Path("results_live.csv")
 SUMMARY_FILE = Path("summary_live.csv")
+BEST_PARAMS_FILE = Path("best_params.csv")
 
 level_name = os.getenv("LOG_LEVEL", "INFO").upper()
 level = getattr(logging, level_name, logging.INFO)

--- a/trading_backtest/utils/io_utils.py
+++ b/trading_backtest/utils/io_utils.py
@@ -12,3 +12,11 @@ def save_csv(df: pd.DataFrame, path: str | Path) -> None:
     """Save a DataFrame to CSV without index."""
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     df.to_csv(path, index=False)
+
+
+def save_best_params(params: dict, strategy: str, path: str | Path) -> None:
+    """Append ``params`` and ``strategy`` name to CSV at ``path``."""
+    file_path = Path(path)
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    row = pd.DataFrame([{"strategy": strategy, **params}])
+    row.to_csv(file_path, mode="a", header=not file_path.exists(), index=False)


### PR DESCRIPTION
## Summary
- add `BEST_PARAMS_FILE` constant
- add `save_best_params` helper to append parameters to CSV
- call helper from CLI after running optimization
- test CLI writes best parameters
- fix `test_data_file_default` expectation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f874f3f48323aa11b5cf12ed45e2